### PR TITLE
Add settings page with console logo toggle

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -83,6 +83,22 @@
             </div>
             <span class="nav-label">Analyses</span>
           </router-link>
+
+          <router-link
+            to="/settings"
+            class="nav-destination"
+            :class="{ active: $route.name === 'settings' }"
+          >
+            <div class="nav-indicator" aria-hidden="true"></div>
+            <div class="nav-icon-container">
+              <svg class="nav-icon" viewBox="0 0 24 24" fill="currentColor">
+                <path
+                  d="M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.07-.94l2.03-1.58c.18-.14.23-.41.12-.62l-1.92-3.32c-.11-.21-.36-.3-.58-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.14A.57.57 0 0 0 14.4 2h-4.8a.57.57 0 0 0-.56.5l-.36 2.14c-.59.24-1.12.56-1.62.94l-2.39-.96a.54.54 0 0 0-.58.22l-1.92 3.32c-.11.21-.06.48.12.62l2.03 1.58c-.05.31-.08.63-.08.94s.03.63.08.94l-2.03 1.58c-.18.14-.23.41-.12.62l1.92 3.32c.11.21.36.3.58.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.14c.04.28.28.5.56.5h4.8c.29 0 .53-.22.56-.5l.36-2.14c.59-.24 1.12-.56 1.62-.94l2.39.96c.22.09.47-.01.58-.22l1.92-3.32c.11-.21.06-.48-.12-.62zm-7.14 2.56a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7z"
+                />
+              </svg>
+            </div>
+            <span class="nav-label">Paramètres</span>
+          </router-link>
         </div>
 
         <div class="user-actions">

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import './utils/consoleLogoControl'
 import { createApp } from 'vue'
 import App from './App.vue'
 import { router, preloadCriticalRoutes } from './router'

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,7 +5,8 @@ const ROUTE_NAMES = {
   HOME: 'home',
   STUDENTS: 'students',
   COMPETENCIES: 'competencies',
-  ANALYSIS: 'analysis'
+  ANALYSIS: 'analysis',
+  SETTINGS: 'settings'
 } as const
 
 const router = createRouter({
@@ -46,6 +47,15 @@ const router = createRouter({
       meta: {
         title: 'Analyse',
         description: 'Analyse des résultats'
+      }
+    },
+    {
+      path: '/settings',
+      name: ROUTE_NAMES.SETTINGS,
+      component: () => import(/* webpackChunkName: "settings" */ '../views/SettingsView.vue'),
+      meta: {
+        title: 'Paramètres',
+        description: 'Personnalisez votre expérience de navigation'
       }
     }
   ]

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1,0 +1,66 @@
+import { ref, readonly } from 'vue'
+
+const STORAGE_KEYS = {
+  SHOW_CONSOLE_LOGOS: 'app.settings.showConsoleLogos'
+} as const
+
+const showConsoleLogos = ref(false)
+
+const readStoredBoolean = (key: string): boolean | null => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    const rawValue = window.localStorage.getItem(key)
+    if (rawValue === null) {
+      return null
+    }
+
+    if (rawValue === 'true' || rawValue === 'false') {
+      return rawValue === 'true'
+    }
+
+    return JSON.parse(rawValue) === true
+  } catch (error) {
+    console.warn('Impossible de lire le paramètre depuis le stockage local:', error)
+    return null
+  }
+}
+
+const persistBoolean = (key: string, value: boolean) => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value))
+  } catch (error) {
+    console.warn('Impossible d\'enregistrer le paramètre dans le stockage local:', error)
+  }
+}
+
+const storedShowConsoleLogos = readStoredBoolean(STORAGE_KEYS.SHOW_CONSOLE_LOGOS)
+if (typeof storedShowConsoleLogos === 'boolean') {
+  showConsoleLogos.value = storedShowConsoleLogos
+}
+
+const setShowConsoleLogos = (value: boolean) => {
+  showConsoleLogos.value = value
+  persistBoolean(STORAGE_KEYS.SHOW_CONSOLE_LOGOS, value)
+}
+
+const toggleShowConsoleLogos = () => {
+  setShowConsoleLogos(!showConsoleLogos.value)
+}
+
+export const getShowConsoleLogosRef = () => showConsoleLogos
+
+export const useSettingsStore = () => {
+  return {
+    showConsoleLogos: readonly(showConsoleLogos),
+    setShowConsoleLogos,
+    toggleShowConsoleLogos
+  }
+}
+

--- a/src/utils/consoleLogoControl.ts
+++ b/src/utils/consoleLogoControl.ts
@@ -1,0 +1,44 @@
+import { getShowConsoleLogosRef } from '@/stores/settingsStore'
+
+const showConsoleLogos = getShowConsoleLogosRef()
+
+type ConsoleMethod = 'log' | 'info' | 'debug' | 'warn' | 'error'
+
+type ConsoleMethodMap = Record<ConsoleMethod, (...args: unknown[]) => void>
+
+const originalConsoleMethods: ConsoleMethodMap = {
+  log: console.log.bind(console),
+  info: console.info.bind(console),
+  debug: console.debug.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console)
+}
+
+const emojiPattern = /\p{Extended_Pictographic}+\s*/gu
+
+const sanitizeArguments = (args: unknown[]): unknown[] => {
+  if (showConsoleLogos.value) {
+    return args
+  }
+
+  return args.map((arg) => {
+    if (typeof arg === 'string') {
+      return arg.replace(emojiPattern, '').replace(/^\s+/, '')
+    }
+    return arg
+  })
+}
+
+const createConsoleWrapper = (method: ConsoleMethod) => {
+  return (...args: unknown[]) => {
+    const processedArgs = sanitizeArguments(args)
+    originalConsoleMethods[method](...processedArgs)
+  }
+}
+
+console.log = createConsoleWrapper('log')
+console.info = createConsoleWrapper('info')
+console.debug = createConsoleWrapper('debug')
+console.warn = createConsoleWrapper('warn')
+console.error = createConsoleWrapper('error')
+

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1,0 +1,253 @@
+<template>
+  <main class="settings-page" role="main">
+    <section class="settings-header">
+      <h1 class="settings-title">Paramètres</h1>
+      <p class="settings-subtitle">
+        Personnalisez votre expérience et contrôlez les options de l'application.
+      </p>
+    </section>
+
+    <section class="settings-section" aria-labelledby="console-settings-title">
+      <div class="section-header">
+        <h2 id="console-settings-title" class="section-title">Console</h2>
+        <p class="section-description">
+          Gérez l'affichage des éléments décoratifs présents dans les journaux de l'application.
+        </p>
+      </div>
+
+      <article class="setting-card" aria-live="polite">
+        <div class="setting-card__content">
+          <h3 class="setting-card__title">Afficher les logos dans la console</h3>
+          <p class="setting-card__description">
+            Activez cette option pour conserver les icônes et les indicateurs visuels dans les messages de journalisation.
+            Lorsqu'elle est désactivée, seuls les messages textuels sont affichés pour une lecture plus sobre.
+          </p>
+          <p class="setting-card__status" :class="{ 'is-enabled': isConsoleLogoEnabled }">
+            {{ isConsoleLogoEnabled ? 'Activé' : 'Désactivé' }}
+          </p>
+        </div>
+
+        <label class="md3-switch">
+          <input
+            id="console-logos-switch"
+            type="checkbox"
+            role="switch"
+            :checked="isConsoleLogoEnabled"
+            :aria-checked="String(isConsoleLogoEnabled)"
+            aria-describedby="console-settings-title"
+            @change="handleConsoleLogoToggle"
+          />
+          <span class="md3-switch__track">
+            <span class="md3-switch__handle"></span>
+          </span>
+        </label>
+      </article>
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useSettingsStore } from '@/stores/settingsStore'
+
+const { showConsoleLogos, setShowConsoleLogos } = useSettingsStore()
+
+const isConsoleLogoEnabled = computed(() => showConsoleLogos.value)
+
+const handleConsoleLogoToggle = (event: Event) => {
+  const target = event.target as HTMLInputElement | null
+  if (!target) {
+    return
+  }
+
+  setShowConsoleLogos(target.checked)
+}
+</script>
+
+<style scoped>
+.settings-page {
+  padding: 104px 24px 120px;
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.settings-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.settings-title {
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface, #1b1c1c);
+  margin: 0;
+}
+
+.settings-subtitle {
+  font-size: 1rem;
+  color: var(--md-sys-color-on-surface-variant, #3f4948);
+  margin: 0;
+  max-width: 720px;
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.section-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface, #1b1c1c);
+  margin: 0;
+}
+
+.section-description {
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface-variant, #3f4948);
+  margin: 0;
+  max-width: 720px;
+}
+
+.setting-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 32px;
+  padding: 28px 32px;
+  border-radius: 24px;
+  background: var(--md-sys-color-surface, #ffffff);
+  box-shadow:
+    0px 1px 3px rgba(0, 0, 0, 0.15),
+    0px 1px 2px rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--md-sys-color-outline-variant, #dbe4e4);
+}
+
+.setting-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+}
+
+.setting-card__title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface, #1b1c1c);
+  margin: 0;
+}
+
+.setting-card__description {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--md-sys-color-on-surface-variant, #3f4948);
+  margin: 0;
+}
+
+.setting-card__status {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--md-sys-color-on-surface-variant, #3f4948);
+  margin: 0;
+}
+
+.setting-card__status.is-enabled {
+  color: var(--md-sys-color-primary, #006a6b);
+}
+
+.md3-switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.md3-switch input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.md3-switch__track {
+  position: relative;
+  width: 52px;
+  height: 32px;
+  background: color-mix(in srgb, var(--md-sys-color-surface-variant, #dbe4e4) 80%, transparent);
+  border-radius: 16px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 4px;
+  transition:
+    background-color 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--md-sys-color-outline-variant, #bfc8c7) 60%, transparent);
+}
+
+.md3-switch__handle {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow:
+    0px 1px 3px rgba(0, 0, 0, 0.15),
+    0px 1px 2px rgba(0, 0, 0, 0.3);
+  transform: translateX(0);
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.md3-switch input:checked + .md3-switch__track {
+  background: var(--md-sys-color-primary, #006a6b);
+  box-shadow: none;
+}
+
+.md3-switch input:checked + .md3-switch__track .md3-switch__handle {
+  transform: translateX(20px);
+  background: #ffffff;
+}
+
+.md3-switch input:focus-visible + .md3-switch__track {
+  outline: 3px solid color-mix(in srgb, var(--md-sys-color-primary, #006a6b) 40%, transparent);
+  outline-offset: 4px;
+}
+
+.md3-switch input:disabled + .md3-switch__track {
+  cursor: not-allowed;
+  opacity: 0.38;
+}
+
+@media (max-width: 768px) {
+  .settings-page {
+    padding: 88px 16px 112px;
+  }
+
+  .setting-card {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 20px;
+    padding: 24px;
+  }
+}
+
+@media (max-width: 480px) {
+  .settings-title {
+    font-size: 1.75rem;
+  }
+
+  .section-title {
+    font-size: 1.25rem;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- add a dedicated settings route and surface it in the bottom navigation
- build a settings view with a Material 3 switch to control decorative console logos
- centralize console logo preferences with persistence and sanitize console output accordingly

## Testing
- npm run test:unit:run
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc59f8f1dc83208261ed18f673f47e