### PR TITLE
Fix aria-checked type

### DIFF
--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -33,7 +33,7 @@
             type="checkbox"
             role="switch"
             :checked="isConsoleLogoEnabled"
-            :aria-checked="String(isConsoleLogoEnabled)"
+            :aria-checked="consoleLogoAriaChecked"
             aria-describedby="console-settings-title"
             @change="handleConsoleLogoToggle"
           />
@@ -53,6 +53,10 @@ import { useSettingsStore } from '@/stores/settingsStore'
 const { showConsoleLogos, setShowConsoleLogos } = useSettingsStore()
 
 const isConsoleLogoEnabled = computed(() => showConsoleLogos.value)
+
+const consoleLogoAriaChecked = computed<'true' | 'false'>(() =>
+  isConsoleLogoEnabled.value ? 'true' : 'false'
+)
 
 const handleConsoleLogoToggle = (event: Event) => {
   const target = event.target as HTMLInputElement | null


### PR DESCRIPTION
## Summary
- ensure the Settings toggle switch exposes a typed aria-checked value instead of a generic string
- add a dedicated computed property that returns the valid `'true' | 'false'` values for screen readers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc5e0ef388832094e58cb23572dcc9