### PR TITLE
feat: allow toggling dark mode from settings

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -152,7 +152,8 @@ watch(isExpanded, (expanded) => {
 
 <style scoped>
 /* Material Design 3 Variables */
-:root {
+:root,
+:root[data-theme='light'] {
   --md-sys-color-primary: #006a6b;
   --md-sys-color-on-primary: #ffffff;
   --md-sys-color-primary-container: #6ff7f5;
@@ -170,6 +171,25 @@ watch(isExpanded, (expanded) => {
   --md-elevation-level-0: none;
   --md-elevation-level-1: 0px 1px 3px 1px rgba(0, 0, 0, 0.15), 0px 1px 2px 0px rgba(0, 0, 0, 0.3);
   --md-elevation-level-2: 0px 2px 6px 2px rgba(0, 0, 0, 0.15), 0px 1px 2px 0px rgba(0, 0, 0, 0.3);
+  color-scheme: light;
+}
+
+:root[data-theme='dark'] {
+  --md-sys-color-primary: #4dd6d4;
+  --md-sys-color-on-primary: #003738;
+  --md-sys-color-primary-container: #004f50;
+  --md-sys-color-on-primary-container: #6ff7f5;
+  --md-sys-color-secondary-container: #1e3535;
+  --md-sys-color-on-secondary-container: #cce8e7;
+  --md-sys-color-surface: #0e1515;
+  --md-sys-color-on-surface: #e1e3e2;
+  --md-sys-color-surface-container: #1a2020;
+  --md-sys-color-surface-container-low: #161b1b;
+  --md-sys-color-surface-variant: #3f4948;
+  --md-sys-color-on-surface-variant: #bfc8c7;
+  --md-sys-color-outline: #899392;
+  --md-sys-color-outline-variant: #3f4948;
+  color-scheme: dark;
 }
 
 /* App Header */
@@ -960,8 +980,13 @@ watch(isExpanded, (expanded) => {
 }
 
 /* Dark Theme */
+html[data-theme='dark'] .navigation-drawer,
+html[data-theme='dark'] .drawer-content {
+  background: #1a1c1c;
+}
+
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     --md-sys-color-primary: #4dd6d4;
     --md-sys-color-on-primary: #003738;
     --md-sys-color-primary-container: #004f50;
@@ -976,13 +1001,11 @@ watch(isExpanded, (expanded) => {
     --md-sys-color-on-surface-variant: #bfc8c7;
     --md-sys-color-outline: #899392;
     --md-sys-color-outline-variant: #3f4948;
+    color-scheme: dark;
   }
 
-  .navigation-drawer {
-    background: #1a1c1c;
-  }
-
-  .drawer-content {
+  html:not([data-theme]) .navigation-drawer,
+  html:not([data-theme]) .drawer-content {
     background: #1a1c1c;
   }
 }

--- a/src/components/LoadingSpinner.vue
+++ b/src/components/LoadingSpinner.vue
@@ -53,6 +53,15 @@ withDefaults(defineProps<Props>(), {
   100% { transform: rotate(360deg); }
 }
 
+html[data-theme='dark'] .spinner {
+  border-color: var(--color-surface-variant, #424242);
+  border-top-color: var(--color-primary, #90caf9);
+}
+
+html[data-theme='dark'] .loading-text {
+  color: var(--color-on-surface-variant, #aaa);
+}
+
 /* Dark mode support */
 @media (prefers-color-scheme: dark) {
   .spinner {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1,10 +1,13 @@
-import { ref, readonly } from 'vue'
+import { ref, readonly, computed } from 'vue'
 
 const STORAGE_KEYS = {
-  SHOW_CONSOLE_LOGOS: 'app.settings.showConsoleLogos'
+  SHOW_CONSOLE_LOGOS: 'app.settings.showConsoleLogos',
+  THEME_PREFERENCE: 'app.settings.themePreference'
 } as const
 
 const showConsoleLogos = ref(false)
+type ThemePreference = 'light' | 'dark'
+const themePreference = ref<ThemePreference>('light')
 
 const readStoredBoolean = (key: string): boolean | null => {
   if (typeof window === 'undefined') {
@@ -40,10 +43,77 @@ const persistBoolean = (key: string, value: boolean) => {
   }
 }
 
+const readStoredThemePreference = (key: string): ThemePreference | null => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    const rawValue = window.localStorage.getItem(key)
+    if (rawValue === 'light' || rawValue === 'dark') {
+      return rawValue
+    }
+
+    return null
+  } catch (error) {
+    console.warn('Impossible de lire la préférence de thème depuis le stockage local:', error)
+    return null
+  }
+}
+
+const persistThemePreference = (key: string, value: ThemePreference) => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(key, value)
+  } catch (error) {
+    console.warn('Impossible d\'enregistrer la préférence de thème dans le stockage local:', error)
+  }
+}
+
+const getSystemThemePreference = (): ThemePreference => {
+  if (typeof window === 'undefined') {
+    return 'light'
+  }
+
+  try {
+    const mediaQuery = window.matchMedia?.('(prefers-color-scheme: dark)')
+    if (mediaQuery) {
+      return mediaQuery.matches ? 'dark' : 'light'
+    }
+
+    return 'light'
+  } catch (error) {
+    console.warn('Impossible de déterminer la préférence système pour le thème:', error)
+    return 'light'
+  }
+}
+
+const applyThemePreference = (value: ThemePreference) => {
+  if (typeof document === 'undefined') {
+    return
+  }
+
+  const rootElement = document.documentElement
+  rootElement.setAttribute('data-theme', value)
+  rootElement.style.colorScheme = value
+}
+
 const storedShowConsoleLogos = readStoredBoolean(STORAGE_KEYS.SHOW_CONSOLE_LOGOS)
 if (typeof storedShowConsoleLogos === 'boolean') {
   showConsoleLogos.value = storedShowConsoleLogos
 }
+
+const storedThemePreference = readStoredThemePreference(STORAGE_KEYS.THEME_PREFERENCE)
+if (storedThemePreference) {
+  themePreference.value = storedThemePreference
+} else {
+  themePreference.value = getSystemThemePreference()
+}
+
+applyThemePreference(themePreference.value)
 
 const setShowConsoleLogos = (value: boolean) => {
   showConsoleLogos.value = value
@@ -54,13 +124,29 @@ const toggleShowConsoleLogos = () => {
   setShowConsoleLogos(!showConsoleLogos.value)
 }
 
+const setThemePreference = (value: ThemePreference) => {
+  themePreference.value = value
+  persistThemePreference(STORAGE_KEYS.THEME_PREFERENCE, value)
+  applyThemePreference(value)
+}
+
+const toggleThemePreference = () => {
+  setThemePreference(themePreference.value === 'dark' ? 'light' : 'dark')
+}
+
 export const getShowConsoleLogosRef = () => showConsoleLogos
+
+const isDarkThemeEnabled = computed(() => themePreference.value === 'dark')
 
 export const useSettingsStore = () => {
   return {
     showConsoleLogos: readonly(showConsoleLogos),
     setShowConsoleLogos,
-    toggleShowConsoleLogos
+    toggleShowConsoleLogos,
+    themePreference: readonly(themePreference),
+    setThemePreference,
+    toggleThemePreference,
+    isDarkThemeEnabled
   }
 }
 

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -14,6 +14,42 @@
         </p>
       </section>
 
+      <section class="settings-section" aria-labelledby="appearance-settings-title">
+        <div class="section-header">
+          <h2 id="appearance-settings-title" class="section-title">Apparence</h2>
+          <p class="section-description">
+            Choisissez entre le mode clair et le mode sombre pour adapter l'interface à votre environnement.
+          </p>
+        </div>
+
+        <article class="setting-card" aria-live="polite">
+          <div class="setting-card__content">
+            <h3 class="setting-card__title">Activer le mode sombre</h3>
+            <p class="setting-card__description">
+              Utilisez ce paramètre pour basculer l'application vers un thème sombre plus confortable dans les environnements peu lumineux.
+            </p>
+            <p class="setting-card__status" :class="{ 'is-enabled': isDarkModeEnabled }">
+              {{ isDarkModeEnabled ? 'Activé' : 'Désactivé' }}
+            </p>
+          </div>
+
+          <label class="md3-switch">
+            <input
+              id="dark-mode-switch"
+              type="checkbox"
+              role="switch"
+              :checked="isDarkModeEnabled"
+              :aria-checked="darkModeAriaChecked"
+              aria-describedby="appearance-settings-title"
+              @change="handleDarkModeToggle"
+            />
+            <span class="md3-switch__track">
+              <span class="md3-switch__handle"></span>
+            </span>
+          </label>
+        </article>
+      </section>
+
       <section class="settings-section" aria-labelledby="console-settings-title">
         <div class="section-header">
           <h2 id="console-settings-title" class="section-title">Console</h2>
@@ -59,13 +95,27 @@ import { computed } from 'vue'
 import TopAppBar from '@/components/TopAppBar.vue'
 import { useSettingsStore } from '@/stores/settingsStore'
 
-const { showConsoleLogos, setShowConsoleLogos } = useSettingsStore()
+const { showConsoleLogos, setShowConsoleLogos, isDarkThemeEnabled, setThemePreference } = useSettingsStore()
 
 const isConsoleLogoEnabled = computed(() => showConsoleLogos.value)
+const isDarkModeEnabled = computed(() => isDarkThemeEnabled.value)
 
 const consoleLogoAriaChecked = computed<'true' | 'false'>(() =>
   isConsoleLogoEnabled.value ? 'true' : 'false'
 )
+
+const darkModeAriaChecked = computed<'true' | 'false'>(() =>
+  isDarkModeEnabled.value ? 'true' : 'false'
+)
+
+const handleDarkModeToggle = (event: Event) => {
+  const target = event.target as HTMLInputElement | null
+  if (!target) {
+    return
+  }
+
+  setThemePreference(target.checked ? 'dark' : 'light')
+}
 
 const handleConsoleLogoToggle = (event: Event) => {
   const target = event.target as HTMLInputElement | null


### PR DESCRIPTION
## Summary
- store the user theme preference and apply the matching data-theme attribute to the document
- expose a dark mode toggle in the settings page wired to the shared settings store
- ensure header tokens and loading spinner styles react to the dark theme attribute alongside system preferences

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc6844f3f08320b84c0fd884c4ce83