### PR TITLE
Replace competencies menu with Material 3 tabs

### DIFF
--- a/src/views/CompetenciesView.vue
+++ b/src/views/CompetenciesView.vue
@@ -5,15 +5,23 @@
       :title="currentPageTitle"
       :subtitle="currentPageDescription"
       variant="medium"
-    >
-      <template #trailing>
-        <ThreeDotMenu
-          v-model="activeView"
-          :items="menuItems"
-          @item-selected="handleMenuSelection"
-        />
-      </template>
-    </TopAppBar>
+    />
+
+    <!-- Material 3 Tabs -->
+    <div class="tabs-container">
+      <div class="tabs-bar">
+        <button
+          v-for="tab in tabItems"
+          :key="tab.id"
+          class="tab"
+          :class="{ active: activeView === tab.value }"
+          @click="activeView = tab.value"
+        >
+          <span class="tab-label">{{ tab.label }}</span>
+          <div class="tab-indicator"></div>
+        </button>
+      </div>
+    </div>
 
     <!-- Main Content -->
     <main class="main-content">
@@ -736,12 +744,9 @@
 
 /* eslint-disable no-undef */
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, defineAsyncComponent } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { useCompetencyFrameworkStore } from '../stores/studentsStore'
 import type { ResultTypeConfig, ResultTypeConfigValue } from '@/types/evaluation'
-
-// Lazy load heavy services and components
-const ThreeDotMenu = defineAsyncComponent(() => import('@/components/ThreeDotMenu.vue'))
 
 // Import lightweight components normally
 import TopAppBar from '@/components/TopAppBar.vue'
@@ -864,34 +869,23 @@ function getPageDescription(): string {
 const currentPageTitle = computed(() => getPageTitle())
 const currentPageDescription = computed(() => getPageDescription())
 
-const menuItems = computed(() => [
+const tabItems = computed(() => [
   {
     id: 'tree',
     label: 'Référentiels',
-    icon: 'account_tree',
-    value: 'tree',
-    selected: activeView.value === 'tree'
+    value: 'tree'
   },
   {
     id: 'types',
     label: 'Types de résultats',
-    icon: 'category',
-    value: 'types',
-    selected: activeView.value === 'types'
+    value: 'types'
   },
   {
     id: 'import',
     label: 'Import/Export',
-    icon: 'upload',
-    value: 'import',
-    selected: activeView.value === 'import'
+    value: 'import'
   }
 ])
-
-// Menu handling
-const handleMenuSelection = (item: { value: string | number | boolean }) => {
-  activeView.value = item.value as 'tree' | 'types' | 'import'
-}
 const ghostElement = ref<DomainItem | FieldItem | CompetencyItemDetailed | SpecificCompetencyItem | { isGhost: true } | null>(null)
 const ghostPosition = ref<number>(-1)
 const ghostContext = ref<DragContext | null>(null)
@@ -1964,6 +1958,117 @@ function exportFramework() {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+/* Material 3 Tabs */
+.tabs-container {
+  position: sticky;
+  top: 0;
+  background: #ffffff;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant, #c4c7c5);
+  z-index: 10;
+}
+
+.tabs-bar {
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.tabs-bar::-webkit-scrollbar {
+  display: none;
+}
+
+.tab {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: 'Roboto', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: 0.1px;
+  color: var(--md-sys-color-on-surface-variant, #49454f);
+  white-space: nowrap;
+  transition: all 0.2s cubic-bezier(0.2, 0, 0, 1);
+  outline: none;
+  overflow: hidden;
+}
+
+.tab::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--md-sys-color-on-surface, #1d1b20);
+  opacity: 0;
+  transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1);
+}
+
+.tab:hover::before {
+  opacity: 0.08;
+}
+
+.tab:focus::before {
+  opacity: 0.12;
+}
+
+.tab:active::before {
+  opacity: 0.12;
+}
+
+.tab.active {
+  color: var(--md-sys-color-primary, #6750a4);
+}
+
+.tab-label {
+  position: relative;
+  z-index: 1;
+}
+
+.tab-indicator {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--md-sys-color-primary, #6750a4);
+  border-radius: 3px 3px 0 0;
+  transform: scaleX(0);
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.tab.active .tab-indicator {
+  transform: scaleX(1);
+}
+
+@media (max-width: 768px) {
+  .tabs-container {
+    padding: 0 16px;
+  }
+
+  .tabs-bar {
+    padding: 0;
+  }
+
+  .tab {
+    min-width: 120px;
+    padding: 12px 8px;
+    font-size: 13px;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- replace the overflow menu on the competencies page with Material 3 tabs for navigating the views
- add scoped Material 3 tab styling to keep the new navigation consistent with the design system

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc6961b4588320b3aa60e03675c26e