### PR TITLE
Fix CompetenciesView tab typing

### DIFF
--- a/src/views/CompetenciesView.vue
+++ b/src/views/CompetenciesView.vue
@@ -815,7 +815,15 @@ interface DragContext {
 
 // État réactif local
 // const searchTerm = ref('') // Fonction de recherche temporairement désactivée
-const activeView = ref<'tree' | 'types' | 'import'>('tree')
+type ActiveView = 'tree' | 'types' | 'import'
+
+interface TabItem {
+  id: ActiveView
+  label: string
+  value: ActiveView
+}
+
+const activeView = ref<ActiveView>('tree')
 const showAddModal = ref(false)
 const showEditModal = ref(false)
 const showDeleteModal = ref(false)
@@ -869,7 +877,7 @@ function getPageDescription(): string {
 const currentPageTitle = computed(() => getPageTitle())
 const currentPageDescription = computed(() => getPageDescription())
 
-const tabItems = computed(() => [
+const tabItems = computed<TabItem[]>(() => [
   {
     id: 'tree',
     label: 'Référentiels',


### PR DESCRIPTION
## Summary
- define a dedicated ActiveView union type and TabItem interface for the competencies tabs
- type the active view ref and computed tab metadata to keep tab values constrained to the allowed views

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc6b5de4388320b05df08a59e38859