### PR TITLE
Refine dark mode tokens and evaluation table

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -59,7 +59,8 @@ body {
     'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #ffffff;
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
 }
 
 * {

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -151,47 +151,6 @@ watch(isExpanded, (expanded) => {
 </script>
 
 <style scoped>
-/* Material Design 3 Variables */
-:root,
-:root[data-theme='light'] {
-  --md-sys-color-primary: #006a6b;
-  --md-sys-color-on-primary: #ffffff;
-  --md-sys-color-primary-container: #6ff7f5;
-  --md-sys-color-on-primary-container: #002020;
-  --md-sys-color-secondary-container: #cce8e7;
-  --md-sys-color-on-secondary-container: #041f1f;
-  --md-sys-color-surface: #fefefe;
-  --md-sys-color-on-surface: #1b1c1c;
-  --md-sys-color-surface-container: #f0f4f3;
-  --md-sys-color-surface-container-low: #f5f9f8;
-  --md-sys-color-surface-variant: #dbe4e4;
-  --md-sys-color-on-surface-variant: #3f4948;
-  --md-sys-color-outline: #6f7978;
-  --md-sys-color-outline-variant: #bfc8c7;
-  --md-elevation-level-0: none;
-  --md-elevation-level-1: 0px 1px 3px 1px rgba(0, 0, 0, 0.15), 0px 1px 2px 0px rgba(0, 0, 0, 0.3);
-  --md-elevation-level-2: 0px 2px 6px 2px rgba(0, 0, 0, 0.15), 0px 1px 2px 0px rgba(0, 0, 0, 0.3);
-  color-scheme: light;
-}
-
-:root[data-theme='dark'] {
-  --md-sys-color-primary: #4dd6d4;
-  --md-sys-color-on-primary: #003738;
-  --md-sys-color-primary-container: #004f50;
-  --md-sys-color-on-primary-container: #6ff7f5;
-  --md-sys-color-secondary-container: #1e3535;
-  --md-sys-color-on-secondary-container: #cce8e7;
-  --md-sys-color-surface: #0e1515;
-  --md-sys-color-on-surface: #e1e3e2;
-  --md-sys-color-surface-container: #1a2020;
-  --md-sys-color-surface-container-low: #161b1b;
-  --md-sys-color-surface-variant: #3f4948;
-  --md-sys-color-on-surface-variant: #bfc8c7;
-  --md-sys-color-outline: #899392;
-  --md-sys-color-outline-variant: #3f4948;
-  color-scheme: dark;
-}
-
 /* App Header */
 .app-header {
   position: fixed;
@@ -613,7 +572,7 @@ watch(isExpanded, (expanded) => {
   padding: 0 16px;
   min-height: 64px;
   width: 100%;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
 }
 
 .nav-drawer-button {
@@ -693,8 +652,8 @@ watch(isExpanded, (expanded) => {
   bottom: 0;
   width: 360px;
   max-width: 80vw;
-  background: #ffffff !important;
-  background-color: #ffffff !important;
+  background: var(--md-sys-color-surface) !important;
+  background-color: var(--md-sys-color-surface) !important;
   box-shadow:
     0px 1px 3px 1px rgba(0, 0, 0, 0.15),
     0px 1px 2px 0px rgba(0, 0, 0, 0.3);
@@ -714,7 +673,7 @@ watch(isExpanded, (expanded) => {
   flex-direction: column;
   height: 100%;
   padding: 0;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
 }
 
 .drawer-header {
@@ -722,8 +681,8 @@ watch(isExpanded, (expanded) => {
   align-items: center;
   justify-content: space-between;
   padding: 16px 24px;
-  border-bottom: 1px solid #e0e0e0;
-  background: #ffffff;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  background: var(--md-sys-color-surface);
 }
 
 .drawer-title {
@@ -772,7 +731,7 @@ watch(isExpanded, (expanded) => {
 .drawer-nav {
   flex: 1;
   padding: 12px 0;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
 }
 
 .drawer-destination {
@@ -849,7 +808,7 @@ watch(isExpanded, (expanded) => {
 
 .drawer-actions {
   padding: 12px 0 24px 0;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
 }
 
 .drawer-action {
@@ -982,32 +941,12 @@ watch(isExpanded, (expanded) => {
 /* Dark Theme */
 html[data-theme='dark'] .navigation-drawer,
 html[data-theme='dark'] .drawer-content {
-  background: #1a1c1c;
+  background: var(--md-sys-color-surface-container);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme]) {
-    --md-sys-color-primary: #4dd6d4;
-    --md-sys-color-on-primary: #003738;
-    --md-sys-color-primary-container: #004f50;
-    --md-sys-color-on-primary-container: #6ff7f5;
-    --md-sys-color-secondary-container: #1e3535;
-    --md-sys-color-on-secondary-container: #cce8e7;
-    --md-sys-color-surface: #0e1515;
-    --md-sys-color-on-surface: #e1e3e2;
-    --md-sys-color-surface-container: #1a2020;
-    --md-sys-color-surface-container-low: #161b1b;
-    --md-sys-color-surface-variant: #3f4948;
-    --md-sys-color-on-surface-variant: #bfc8c7;
-    --md-sys-color-outline: #899392;
-    --md-sys-color-outline-variant: #3f4948;
-    color-scheme: dark;
-  }
-
-  html:not([data-theme]) .navigation-drawer,
-  html:not([data-theme]) .drawer-content {
-    background: #1a1c1c;
-  }
+html:not([data-theme]) .navigation-drawer,
+html:not([data-theme]) .drawer-content {
+  background: var(--md-sys-color-surface-container);
 }
 
 /* Focus States for Accessibility */

--- a/src/components/EvaluationPersistenceStatus.vue
+++ b/src/components/EvaluationPersistenceStatus.vue
@@ -154,12 +154,13 @@ const formatBytes = (bytes: number): string => {
 
 <style scoped>
 .persistence-status-container {
-  background: #f8f9fa;
-  border: 1px solid #dee2e6;
+  background: var(--app-table-no-eval-bg);
+  border: 1px solid var(--app-border-subtle);
   border-radius: 0.5rem;
   padding: 1rem;
   margin: 1rem 0;
   font-size: 0.9rem;
+  color: var(--md-sys-color-on-surface);
 }
 
 .status-header {
@@ -171,7 +172,7 @@ const formatBytes = (bytes: number): string => {
 
 .status-header h4 {
   margin: 0;
-  color: #495057;
+  color: var(--md-sys-color-on-surface);
   font-size: 1rem;
 }
 
@@ -181,56 +182,59 @@ const formatBytes = (bytes: number): string => {
   gap: 0.5rem;
 }
 
-.status-badge {
+.status-badge,
+.source-badge {
   padding: 0.25rem 0.5rem;
   border-radius: 0.25rem;
   font-size: 0.8rem;
   font-weight: 600;
+  border: 1px solid transparent;
 }
 
 .status-badge.loading {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--app-status-warning-container);
+  color: var(--app-status-warning-on);
+  border-color: var(--app-status-warning-border);
 }
 
 .status-badge.error {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--app-status-danger-container);
+  color: var(--app-status-danger-on);
+  border-color: var(--app-status-danger-border);
 }
 
 .status-badge.success {
-  background: #d4edda;
-  color: #155724;
+  background: var(--app-status-success-container);
+  color: var(--app-status-success-on);
+  border-color: var(--app-status-success-border);
 }
 
 .status-badge.idle {
-  background: #e2e3e5;
-  color: #6c757d;
+  background: var(--app-status-neutral-container);
+  color: var(--app-status-neutral-on);
+  border-color: var(--app-status-neutral-border);
 }
 
 .source-badge {
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.25rem;
   font-size: 0.75rem;
-  font-weight: 600;
 }
 
 .source-badge.supabase {
-  background: #d4edda;
-  color: #155724;
-  border: 1px solid #c3e6cb;
+  background: var(--app-status-success-container);
+  color: var(--app-status-success-on);
+  border-color: var(--app-status-success-border);
 }
 
 .source-badge.local {
-  background: #fff3cd;
-  color: #856404;
-  border: 1px solid #ffeaa7;
+  background: var(--app-status-warning-container);
+  color: var(--app-status-warning-on);
+  border-color: var(--app-status-warning-border);
 }
 
 .clear-error-btn {
   background: none;
   border: none;
-  color: #dc3545;
+  color: var(--app-icon-danger);
   cursor: pointer;
   font-size: 1.2rem;
   padding: 0.25rem;
@@ -238,8 +242,8 @@ const formatBytes = (bytes: number): string => {
 }
 
 .error-message {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--app-status-danger-container);
+  color: var(--app-status-danger-on);
   padding: 0.5rem;
   border-radius: 0.25rem;
   margin-bottom: 0.75rem;
@@ -257,19 +261,19 @@ const formatBytes = (bytes: number): string => {
   display: flex;
   justify-content: space-between;
   padding: 0.5rem;
-  background: white;
+  background: var(--md-sys-color-surface);
   border-radius: 0.25rem;
-  border: 1px solid #e9ecef;
+  border: 1px solid var(--app-divider);
 }
 
 .stat-label {
-  color: #6c757d;
+  color: var(--app-table-subhead-text);
   font-size: 0.85rem;
 }
 
 .stat-value {
   font-weight: 600;
-  color: #495057;
+  color: var(--md-sys-color-on-surface);
 }
 
 .actions {
@@ -281,18 +285,18 @@ const formatBytes = (bytes: number): string => {
 
 .action-btn {
   padding: 0.375rem 0.75rem;
-  border: 1px solid #dee2e6;
+  border: 1px solid var(--app-border-subtle);
   border-radius: 0.25rem;
-  background: white;
-  color: #495057;
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
   cursor: pointer;
   font-size: 0.85rem;
   transition: all 0.2s ease;
 }
 
 .action-btn:hover:not(:disabled) {
-  background: #e9ecef;
-  border-color: #adb5bd;
+  background: var(--app-table-row-hover);
+  border-color: var(--app-border-strong);
 }
 
 .action-btn:disabled {
@@ -301,23 +305,26 @@ const formatBytes = (bytes: number): string => {
 }
 
 .refresh-btn:hover:not(:disabled) {
-  background: #e3f2fd;
-  color: #1976d2;
+  background: var(--app-status-info-container);
+  color: var(--app-status-info-on);
+  border-color: var(--app-status-info-border);
 }
 
 .export-btn:hover:not(:disabled) {
-  background: #e8f5e8;
-  color: #28a745;
+  background: var(--app-status-success-container);
+  color: var(--app-status-success-on);
+  border-color: var(--app-status-success-border);
 }
 
 .reset-btn:hover:not(:disabled) {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--app-status-warning-container);
+  color: var(--app-status-warning-on);
+  border-color: var(--app-status-warning-border);
 }
 
 .evaluation-stats h5 {
   margin: 0 0 0.5rem 0;
-  color: #495057;
+  color: var(--md-sys-color-on-surface);
   font-size: 0.9rem;
 }
 
@@ -343,39 +350,35 @@ const formatBytes = (bytes: number): string => {
 }
 
 .level-a {
-  background: #d4edda;
-  color: #155724;
+  background: var(--app-status-success-container);
+  color: var(--app-status-success-on);
 }
 
 .level-b {
-  background: #d1ecf1;
-  color: #0c5460;
+  background: var(--app-status-info-container);
+  color: var(--app-status-info-on);
 }
 
 .level-c {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--app-status-warning-container);
+  color: var(--app-status-warning-on);
 }
 
-.level-d {
-  background: #f8d7da;
-  color: #721c24;
-}
-
+.level-d,
 .level-e {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--app-status-danger-container);
+  color: var(--app-status-danger-on);
 }
 
 .level-n-a {
-  background: #e2e3e5;
-  color: #6c757d;
+  background: var(--app-status-neutral-container);
+  color: var(--app-status-neutral-on);
 }
 
 .count {
   font-size: 0.8rem;
   font-weight: 600;
-  color: #495057;
+  color: var(--md-sys-color-on-surface);
 }
 
 @media (max-width: 768px) {

--- a/src/components/EvaluationTable.vue
+++ b/src/components/EvaluationTable.vue
@@ -532,13 +532,13 @@ watch(searchTerm, (newTerm) => {
   flex-direction: column;
   height: 100vh;
   overflow: hidden;
-  background-color: #ffffff;
+  background-color: var(--md-sys-color-surface);
 }
 
 .table-header {
   padding: 1rem;
-  background: #ffffff;
-  border-bottom: 1px solid #e9ecef;
+  background: var(--app-table-header-bg);
+  border-bottom: 1px solid var(--app-divider);
   flex-shrink: 0;
   display: flex;
   justify-content: space-between;
@@ -552,13 +552,13 @@ watch(searchTerm, (newTerm) => {
 
 .header-main h2 {
   margin: 0 0 0.5rem 0;
-  color: #2c3e50;
+  color: var(--md-sys-color-on-surface);
   font-size: 1.5rem;
 }
 
 .table-description {
   margin: 0;
-  color: #6c757d;
+  color: var(--app-table-subhead-text);
   font-size: 0.95rem;
 }
 
@@ -571,14 +571,14 @@ watch(searchTerm, (newTerm) => {
 
 .controls-label {
   font-size: 0.9rem;
-  color: #6c757d;
+  color: var(--app-table-subhead-text);
   font-weight: 500;
 }
 
 .restore-column-btn {
-  background: #e3f2fd;
-  color: #1976d2;
-  border: 1px solid #bbdefb;
+  background: var(--app-tonal-button-bg);
+  color: var(--app-tonal-button-text);
+  border: 1px solid var(--app-tonal-button-border);
   padding: 0.25rem 0.5rem;
   border-radius: 0.25rem;
   font-size: 0.8rem;
@@ -587,8 +587,9 @@ watch(searchTerm, (newTerm) => {
 }
 
 .restore-column-btn:hover {
-  background: #bbdefb;
-  color: #0d47a1;
+  background: var(--app-tonal-button-hover-bg);
+  color: var(--app-tonal-button-hover-text);
+  border-color: var(--app-tonal-button-hover-bg);
 }
 
 .table-wrapper {
@@ -614,26 +615,17 @@ watch(searchTerm, (newTerm) => {
   position: sticky;
   top: 0;
   z-index: 20;
-  background: #fff;
+  background: var(--app-table-sticky-bg);
 }
 
-.evaluation-table th {
-  background: #f8f9fa;
-  border: 1px solid #dee2e6;
-  padding: 0.75rem 0.5rem;
-  text-align: left;
-  font-weight: 600;
-  color: #495057;
-  vertical-align: top;
-}
-
+.evaluation-table th,
 .hierarchy-header {
-  background: #f8f9fa;
-  border: 1px solid #dee2e6;
+  background: var(--app-table-header-bg);
+  border: 1px solid var(--app-border-subtle);
   padding: 0.75rem 0.5rem;
   text-align: left;
   font-weight: 600;
-  color: #495057;
+  color: var(--app-table-header-text);
   vertical-align: top;
 }
 
@@ -641,30 +633,28 @@ watch(searchTerm, (newTerm) => {
   min-width: 150px;
   max-width: 150px;
   width: 150px;
-  background: #f0f8ff !important;
-  background-color: #f0f8ff !important;
+  background: var(--app-table-hierarchy-domain-bg) !important;
 }
 
 .field-col {
   min-width: 200px;
   max-width: 200px;
   width: 200px;
-  background: #faf0ff !important;
-  background-color: #faf0ff !important;
+  background: var(--app-table-hierarchy-field-bg) !important;
 }
 
 .competency-col {
   min-width: 250px;
   max-width: 250px;
   width: 250px;
-  background: #fff8f0 !important;
-  background-color: #fff8f0 !important;
+  background: var(--app-table-hierarchy-competency-bg) !important;
 }
 
 .specific-competency-col {
   min-width: 300px;
   max-width: 300px;
   width: 300px;
+  background: var(--app-table-hierarchy-specific-bg) !important;
 }
 
 .hierarchy-header .header-content {
@@ -689,10 +679,11 @@ watch(searchTerm, (newTerm) => {
   border-radius: 0.25rem;
   transition: all 0.2s ease;
   opacity: 0.7;
+  color: var(--app-icon-muted);
 }
 
 .visibility-btn:hover {
-  background: rgba(0, 0, 0, 0.1);
+  background: var(--app-table-row-hover);
   opacity: 1;
 }
 
@@ -701,7 +692,7 @@ watch(searchTerm, (newTerm) => {
   border: none;
   font-size: 1.2rem;
   cursor: pointer;
-  color: #6c757d;
+  color: var(--app-icon-muted);
   padding: 0;
   width: 20px;
   height: 20px;
@@ -711,7 +702,7 @@ watch(searchTerm, (newTerm) => {
 }
 
 .clear-search-btn:hover {
-  color: #dc3545;
+  color: var(--app-icon-danger);
 }
 
 .search-container {
@@ -721,15 +712,17 @@ watch(searchTerm, (newTerm) => {
 .search-input {
   width: 100%;
   padding: 0.375rem 0.5rem;
-  border: 1px solid #ced4da;
+  border: 1px solid var(--app-table-search-border);
   border-radius: 0.25rem;
   font-size: 0.875rem;
+  background: var(--app-table-sticky-bg);
+  color: var(--md-sys-color-on-surface);
 }
 
 .search-input:focus {
   outline: none;
-  border-color: #80bdff;
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+  border-color: var(--app-table-search-focus-border);
+  box-shadow: 0 0 0 0.2rem var(--app-focus-ring);
 }
 
 .student-header {
@@ -738,6 +731,7 @@ watch(searchTerm, (newTerm) => {
   width: 90px;
   text-align: center;
   writing-mode: horizontal-tb;
+  color: var(--md-sys-color-on-surface);
 }
 
 .student-name {
@@ -755,13 +749,13 @@ watch(searchTerm, (newTerm) => {
 .sticky-left {
   position: sticky;
   z-index: 10;
-  background: #fff;
+  background: var(--app-table-sticky-bg);
 }
 
 .domain-col,
 .domain-cell {
   left: 0;
-  border-right: 1px solid #dee2e6;
+  border-right: 1px solid var(--app-border-subtle);
   z-index: 14;
   opacity: 1;
   backdrop-filter: none;
@@ -770,7 +764,7 @@ watch(searchTerm, (newTerm) => {
 .field-col,
 .field-cell {
   left: 150px;
-  border-right: 1px solid #dee2e6;
+  border-right: 1px solid var(--app-border-subtle);
   z-index: 13;
   opacity: 1;
   backdrop-filter: none;
@@ -779,7 +773,7 @@ watch(searchTerm, (newTerm) => {
 .competency-col,
 .competency-cell {
   left: 350px;
-  border-right: 1px solid #dee2e6;
+  border-right: 1px solid var(--app-border-subtle);
   z-index: 12;
   opacity: 1;
   backdrop-filter: none;
@@ -788,28 +782,30 @@ watch(searchTerm, (newTerm) => {
 .specific-competency-col,
 .specific-competency-cell {
   left: 600px;
-  border-right: 2px solid #dee2e6;
+  border-right: 2px solid var(--app-border-strong);
   z-index: 11;
 }
 
 /* Row styles */
 .competency-row {
-  border-bottom: 1px solid #e9ecef;
+  border-bottom: 1px solid var(--app-divider);
+  background: var(--md-sys-color-surface);
 }
 
 .competency-row:hover {
-  background-color: #f8f9fa;
+  background-color: var(--app-table-row-hover);
 }
 
 .competency-row.type-specificCompetency {
-  background-color: #ffffff;
+  background-color: var(--md-sys-color-surface);
 }
 
 /* Cell styles */
 .evaluation-table td {
-  border: 1px solid #dee2e6;
+  border: 1px solid var(--app-border-subtle);
   padding: 0.5rem;
   vertical-align: top;
+  background: var(--md-sys-color-surface);
 }
 
 .hierarchy-cell {
@@ -817,7 +813,7 @@ watch(searchTerm, (newTerm) => {
   font-size: 0.9rem;
   line-height: 1.4;
   position: sticky;
-  background: #fff;
+  background: var(--app-table-sticky-bg);
 }
 
 .domain-cell {
@@ -825,8 +821,7 @@ watch(searchTerm, (newTerm) => {
   max-width: 150px;
   width: 150px;
   font-weight: 600;
-  background: #f0f8ff !important;
-  background-color: #f0f8ff !important;
+  background: var(--app-table-hierarchy-domain-bg) !important;
 }
 
 .field-cell {
@@ -834,24 +829,21 @@ watch(searchTerm, (newTerm) => {
   max-width: 200px;
   width: 200px;
   font-weight: 500;
-  background: #faf0ff !important;
-  background-color: #faf0ff !important;
+  background: var(--app-table-hierarchy-field-bg) !important;
 }
 
 .competency-cell {
   min-width: 250px;
   max-width: 250px;
   width: 250px;
-  background: #fff8f0 !important;
-  background-color: #fff8f0 !important;
+  background: var(--app-table-hierarchy-competency-bg) !important;
 }
 
 .specific-competency-cell {
   min-width: 300px;
   max-width: 300px;
   width: 300px;
-  background: #ffffff;
-  background-color: #ffffff;
+  background: var(--app-table-hierarchy-specific-bg);
 }
 
 .cell-content {
@@ -882,7 +874,7 @@ watch(searchTerm, (newTerm) => {
 }
 
 .result-cell:hover {
-  background-color: rgba(0, 123, 255, 0.1);
+  background-color: var(--app-table-result-hover);
 }
 
 .result-content {
@@ -904,73 +896,65 @@ watch(searchTerm, (newTerm) => {
 
 /* Result level colors */
 .level-a {
-  background-color: #d4edda;
-  color: #155724;
-  border: 1px solid #c3e6cb;
+  background-color: var(--app-status-success-container);
+  color: var(--app-status-success-on);
+  border: 1px solid var(--app-status-success-border);
 }
 
 .level-b {
-  background-color: #d1ecf1;
-  color: #0c5460;
-  border: 1px solid #bee5eb;
+  background-color: var(--app-status-info-container);
+  color: var(--app-status-info-on);
+  border: 1px solid var(--app-status-info-border);
 }
 
 .level-c {
-  background-color: #fff3cd;
-  color: #856404;
-  border: 1px solid #ffeaa7;
+  background-color: var(--app-status-warning-container);
+  color: var(--app-status-warning-on);
+  border: 1px solid var(--app-status-warning-border);
 }
 
-.level-d {
-  background-color: #f8d7da;
-  color: #721c24;
-  border: 1px solid #f5c6cb;
-}
-
+.level-d,
 .level-e {
-  background-color: #f8d7da;
-  color: #721c24;
-  border: 1px solid #f5c6cb;
+  background-color: var(--app-status-danger-container);
+  color: var(--app-status-danger-on);
+  border: 1px solid var(--app-status-danger-border);
 }
 
 .level-n-a {
-  background-color: #e2e3e5;
-  color: #383d41;
-  border: 1px solid #d6d8db;
+  background-color: var(--app-status-neutral-container);
+  color: var(--app-status-neutral-on);
+  border: 1px solid var(--app-status-neutral-border);
 }
 
 /* Result cell background colors (subtle) */
 .has-result-a {
-  background-color: rgba(212, 237, 218, 0.1);
+  background-color: var(--app-status-success-soft);
 }
 
 .has-result-b {
-  background-color: rgba(209, 236, 241, 0.1);
+  background-color: var(--app-status-info-soft);
 }
 
 .has-result-c {
-  background-color: rgba(255, 243, 205, 0.1);
+  background-color: var(--app-status-warning-soft);
 }
 
-.has-result-d {
-  background-color: rgba(248, 215, 218, 0.1);
-}
-
+.has-result-d,
 .has-result-e {
-  background-color: rgba(248, 215, 218, 0.1);
+  background-color: var(--app-status-danger-soft);
 }
 
 .no-result {
-  background-color: rgba(226, 227, 229, 0.05);
+  background-color: var(--app-status-neutral-soft);
 }
 
 .no-evaluation {
-  background-color: #f8f9fa;
+  background-color: var(--app-table-no-eval-bg);
   cursor: default;
 }
 
 .no-evaluation:hover {
-  background-color: #f8f9fa;
+  background-color: var(--app-table-no-eval-bg);
 }
 
 /* Inline editing styles */
@@ -983,19 +967,19 @@ watch(searchTerm, (newTerm) => {
 .result-select {
   width: 60px;
   padding: 0.25rem;
-  border: 2px solid #007bff;
+  border: 2px solid var(--md-sys-color-primary);
   border-radius: 0.25rem;
   font-size: 0.75rem;
   font-weight: 600;
   text-align: center;
-  background: white;
-  color: #495057;
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
   outline: none;
 }
 
 .result-select:focus {
-  border-color: #0056b3;
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+  border-color: var(--app-table-search-focus-border);
+  box-shadow: 0 0 0 0.2rem var(--app-focus-ring);
 }
 
 /* Custom select dropdown styles */
@@ -1009,8 +993,8 @@ watch(searchTerm, (newTerm) => {
   top: 0;
   left: 50%;
   transform: translateX(-50%);
-  background: #ffffff;
-  border: 2px solid #6750a4;
+  background: var(--app-select-dropdown-bg);
+  border: 2px solid var(--md-sys-color-primary);
   border-radius: 8px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
   z-index: 1000;
@@ -1024,20 +1008,21 @@ watch(searchTerm, (newTerm) => {
   width: 100%;
   padding: 8px 12px;
   border: none;
-  background: #ffffff;
+  background: var(--app-select-dropdown-bg);
   text-align: center;
   font-size: 12px;
   cursor: pointer;
   transition: background-color 0.2s;
+  color: var(--app-select-option-text);
 }
 
 .select-option:hover {
-  background-color: #f3f0ff;
+  background-color: var(--app-select-option-hover-bg);
 }
 
 .select-option.selected {
-  background-color: #6750a4;
-  color: white;
+  background-color: var(--app-select-option-selected-bg);
+  color: var(--app-select-option-selected-text);
 }
 
 .select-option:first-child {
@@ -1051,7 +1036,6 @@ watch(searchTerm, (newTerm) => {
 .select-option:only-child {
   border-radius: 6px;
 }
-
 
 /* Responsive design */
 @media (max-width: 768px) {
@@ -1116,7 +1100,6 @@ watch(searchTerm, (newTerm) => {
     font-size: 0.75rem;
     padding: 0.125rem 0.25rem;
   }
-
 
   .table-header {
     flex-direction: column;
@@ -1198,3 +1181,4 @@ watch(searchTerm, (newTerm) => {
   }
 }
 </style>
+

--- a/src/components/FullscreenDialog.vue
+++ b/src/components/FullscreenDialog.vue
@@ -111,7 +111,7 @@ defineEmits<{
   font-size: 22px;
   font-weight: 400;
   line-height: 28px;
-  color: #1d1b20;
+  color: var(--md-sys-color-on-surface);
   margin: 0;
 }
 
@@ -135,7 +135,7 @@ defineEmits<{
 .fullscreen-content {
   flex: 1;
   overflow-y: auto;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
 }
 
 .fullscreen-body {
@@ -156,7 +156,7 @@ defineEmits<{
   border-radius: 50%;
   cursor: pointer;
   transition: all 0.2s cubic-bezier(0.2, 0, 0, 1);
-  color: #49454f;
+  color: var(--md-sys-color-on-surface-variant);
   position: relative;
 }
 
@@ -174,17 +174,17 @@ defineEmits<{
 }
 
 .icon-btn:hover::before {
-  background: #49454f;
+  background: var(--md-sys-color-on-surface-variant);
   opacity: 0.08;
 }
 
 .icon-btn:focus::before {
-  background: #49454f;
+  background: var(--md-sys-color-on-surface-variant);
   opacity: 0.12;
 }
 
 .icon-btn:active::before {
-  background: #49454f;
+  background: var(--md-sys-color-on-surface-variant);
   opacity: 0.12;
 }
 
@@ -198,7 +198,7 @@ defineEmits<{
   align-items: center;
   gap: 8px;
   background: transparent;
-  color: #6750a4;
+  color: var(--md-sys-color-primary);
   border: none;
   border-radius: 20px;
   padding: 10px 24px;
@@ -219,7 +219,7 @@ defineEmits<{
   left: 0;
   right: 0;
   bottom: 0;
-  background: #6750a4;
+  background: var(--md-sys-color-primary);
   opacity: 0;
   transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1);
 }

--- a/src/components/SelectField.vue
+++ b/src/components/SelectField.vue
@@ -143,18 +143,6 @@ defineExpose({
 </script>
 
 <style scoped>
-/* MD3 Design Tokens */
-:root {
-  --md-sys-color-primary: #6750a4;
-  --md-sys-color-on-surface: #1d1b20;
-  --md-sys-color-on-surface-variant: #49454f;
-  --md-sys-color-outline: #79747e;
-  --md-sys-color-error: #ba1a1a;
-  --md-sys-color-surface: #ffffff;
-  --md-outlined-select-field-container-height: 56px;
-  --md-outlined-select-field-container-shape: 4px;
-}
-
 /* Base Container */
 .md-outlined-select-field {
   position: relative;
@@ -214,7 +202,7 @@ defineExpose({
   font-size: 16px;
   line-height: 24px;
   color: var(--md-sys-color-on-surface-variant);
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   padding: 0 8px;
   pointer-events: none;
   transition: all 150ms cubic-bezier(0.2, 0, 0, 1);

--- a/src/components/TextFieldOutlined.vue
+++ b/src/components/TextFieldOutlined.vue
@@ -212,41 +212,6 @@ defineExpose({
 /* Material Design 3 Outlined Text Field */
 /* Based on https://github.com/material-components/material-web/blob/main/docs/components/text-field.md */
 
-/* MD3 Design Tokens */
-:root {
-  --md-sys-color-primary: #6750a4;
-  --md-sys-color-on-primary: #ffffff;
-  --md-sys-color-primary-container: #eaddff;
-  --md-sys-color-on-primary-container: #21005d;
-  --md-sys-color-surface: #fffbfe;
-  --md-sys-color-on-surface: #1c1b1f;
-  --md-sys-color-on-surface-variant: #49454f;
-  --md-sys-color-outline: #79747e;
-  --md-sys-color-outline-variant: #cac4d0;
-  --md-sys-color-error: #ba1a1a;
-  --md-sys-color-on-error: #ffffff;
-  --md-sys-color-error-container: #ffdad6;
-  --md-sys-color-on-error-container: #410002;
-
-  /* Material 3 Text Field Tokens */
-  --md-outlined-text-field-container-height: 56px;
-  --md-outlined-text-field-container-shape: 4px;
-  --md-outlined-text-field-outline-width: 1px;
-  --md-outlined-text-field-focus-outline-width: 2px;
-  --md-outlined-text-field-disabled-outline-opacity: 0.12;
-
-  /* Typography tokens */
-  --md-sys-typescale-body-large-font: 'Roboto';
-  --md-sys-typescale-body-large-size: 16px;
-  --md-sys-typescale-body-large-weight: 400;
-  --md-sys-typescale-body-large-line-height: 24px;
-
-  --md-sys-typescale-body-small-font: 'Roboto';
-  --md-sys-typescale-body-small-size: 12px;
-  --md-sys-typescale-body-small-weight: 400;
-  --md-sys-typescale-body-small-line-height: 16px;
-}
-
 /* Base Container - Material 3 Outlined Text Field */
 .md-outlined-text-field {
   position: relative;

--- a/src/components/TopAppBar.vue
+++ b/src/components/TopAppBar.vue
@@ -69,7 +69,7 @@ const appBarClasses = computed(() => ({
   align-items: center;
   position: relative;
   width: 100%;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   color: var(--md-sys-color-on-surface, #1d1b20);
   min-height: 64px;
   padding: 0 4px;

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,324 @@
+:root,
+:root[data-theme='light'] {
+  color-scheme: light;
+  --md-sys-color-primary: #006a6b;
+  --md-sys-color-on-primary: #ffffff;
+  --md-sys-color-primary-container: #6ff7f5;
+  --md-sys-color-on-primary-container: #002020;
+  --md-sys-color-secondary-container: #cce8e7;
+  --md-sys-color-on-secondary-container: #041f1f;
+  --md-sys-color-surface: #fefefe;
+  --md-sys-color-on-surface: #1b1c1c;
+  --md-sys-color-surface-container: #f0f4f3;
+  --md-sys-color-surface-container-low: #f5f9f8;
+  --md-sys-color-surface-container-high: #ece6f0;
+  --md-sys-color-surface-variant: #dbe4e4;
+  --md-sys-color-on-surface-variant: #3f4948;
+  --md-sys-color-outline: #6f7978;
+  --md-sys-color-outline-variant: #bfc8c7;
+  --md-sys-color-error: #ba1a1a;
+  --md-sys-color-error-container: #ffdad6;
+  --md-sys-color-on-error: #ffffff;
+  --md-sys-color-on-error-container: #410002;
+  --md-sys-elevation-level0: none;
+  --md-sys-elevation-level1: 0px 1px 3px 1px rgba(0, 0, 0, 0.15),
+    0px 1px 2px 0px rgba(0, 0, 0, 0.3);
+  --md-sys-elevation-level2: 0px 2px 6px 2px rgba(0, 0, 0, 0.15),
+    0px 1px 2px 0px rgba(0, 0, 0, 0.3);
+  --md-sys-elevation-level3: 0px 6px 10px rgba(0, 0, 0, 0.14),
+    0px 1px 18px rgba(0, 0, 0, 0.12),
+    0px 3px 5px rgba(0, 0, 0, 0.2);
+  --md-sys-elevation-level4: 0px 8px 12px rgba(0, 0, 0, 0.14),
+    0px 4px 20px rgba(0, 0, 0, 0.12),
+    0px 3px 6px rgba(0, 0, 0, 0.2);
+  --md-sys-shape-corner-medium: 12px;
+  --md-sys-shape-corner-small: 4px;
+  --md-sys-typescale-body-large-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-body-large-size: 16px;
+  --md-sys-typescale-body-large-weight: 400;
+  --md-sys-typescale-body-large-weight-prominent: 500;
+  --md-sys-typescale-body-large-line-height: 24px;
+  --md-sys-typescale-body-medium-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-body-medium-size: 14px;
+  --md-sys-typescale-body-medium-weight: 400;
+  --md-sys-typescale-body-medium-line-height: 20px;
+  --md-sys-typescale-body-small-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-body-small-size: 12px;
+  --md-sys-typescale-body-small-weight: 400;
+  --md-sys-typescale-body-small-line-height: 16px;
+  --md-sys-typescale-headline-medium-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-headline-medium-size: 28px;
+  --md-sys-typescale-headline-medium-weight: 400;
+  --md-sys-typescale-headline-medium-line-height: 36px;
+  --md-sys-typescale-headline-small-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-headline-small-size: 24px;
+  --md-sys-typescale-headline-small-weight: 400;
+  --md-sys-typescale-headline-small-line-height: 32px;
+  --md-sys-typescale-label-large-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-label-large-size: 14px;
+  --md-sys-typescale-label-large-weight: 500;
+  --md-sys-typescale-label-large-line-height: 20px;
+  --md-sys-typescale-title-large-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-title-large-size: 22px;
+  --md-sys-typescale-title-large-weight: 400;
+  --md-sys-typescale-title-large-line-height: 28px;
+  --md-sys-typescale-title-medium-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-title-medium-size: 16px;
+  --md-sys-typescale-title-medium-weight: 500;
+  --md-sys-typescale-title-medium-line-height: 24px;
+  --md-sys-typescale-title-small-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-title-small-size: 14px;
+  --md-sys-typescale-title-small-weight: 500;
+  --md-sys-typescale-title-small-line-height: 20px;
+  --md-outlined-text-field-container-height: 56px;
+  --md-outlined-text-field-container-shape: 4px;
+  --md-outlined-text-field-outline-width: 1px;
+  --md-outlined-text-field-focus-outline-width: 2px;
+  --md-outlined-text-field-disabled-outline-opacity: 0.12;
+  --md-outlined-select-field-container-height: 56px;
+  --md-outlined-select-field-container-shape: 4px;
+  --color-primary: var(--md-sys-color-primary);
+  --color-on-surface-variant: var(--md-sys-color-on-surface-variant);
+  --color-surface-variant: var(--md-sys-color-surface-variant);
+  --app-border-subtle: #dee2e6;
+  --app-border-strong: #ced4da;
+  --app-divider: #e9ecef;
+  --app-focus-ring: rgba(0, 106, 107, 0.2);
+  --app-icon-muted: var(--md-sys-color-on-surface-variant);
+  --app-icon-danger: var(--md-sys-color-error);
+  --app-tonal-button-bg: var(--md-sys-color-primary-container);
+  --app-tonal-button-border: var(--md-sys-color-outline-variant);
+  --app-tonal-button-text: var(--md-sys-color-on-primary-container);
+  --app-tonal-button-hover-bg: var(--md-sys-color-primary);
+  --app-tonal-button-hover-text: var(--md-sys-color-on-primary);
+  --app-table-header-bg: #f5f7f6;
+  --app-table-header-text: var(--md-sys-color-on-surface);
+  --app-table-subhead-text: var(--md-sys-color-on-surface-variant);
+  --app-table-sticky-bg: var(--md-sys-color-surface);
+  --app-table-row-hover: #eef2f1;
+  --app-table-result-hover: rgba(0, 106, 107, 0.12);
+  --app-table-no-eval-bg: #f5f7f6;
+  --app-table-hierarchy-domain-bg: #e5f3f4;
+  --app-table-hierarchy-field-bg: #f3e9f7;
+  --app-table-hierarchy-competency-bg: #f9f0e6;
+  --app-table-hierarchy-specific-bg: var(--md-sys-color-surface);
+  --app-table-search-border: #ced4da;
+  --app-table-search-focus-border: var(--md-sys-color-primary);
+  --app-select-dropdown-bg: var(--md-sys-color-surface);
+  --app-select-option-text: var(--md-sys-color-on-surface);
+  --app-select-option-hover-bg: #ede9ff;
+  --app-select-option-selected-bg: var(--md-sys-color-primary);
+  --app-select-option-selected-text: var(--md-sys-color-on-primary);
+  --app-status-success-container: #d4edda;
+  --app-status-success-border: #c3e6cb;
+  --app-status-success-on: #155724;
+  --app-status-success-soft: rgba(212, 237, 218, 0.25);
+  --app-status-info-container: #d1ecf1;
+  --app-status-info-border: #bee5eb;
+  --app-status-info-on: #0c5460;
+  --app-status-info-soft: rgba(209, 236, 241, 0.25);
+  --app-status-warning-container: #fff3cd;
+  --app-status-warning-border: #ffeaa7;
+  --app-status-warning-on: #856404;
+  --app-status-warning-soft: rgba(255, 243, 205, 0.25);
+  --app-status-danger-container: #f8d7da;
+  --app-status-danger-border: #f5c6cb;
+  --app-status-danger-on: #721c24;
+  --app-status-danger-soft: rgba(248, 215, 218, 0.25);
+  --app-status-neutral-container: #e2e3e5;
+  --app-status-neutral-border: #d6d8db;
+  --app-status-neutral-on: #383d41;
+  --app-status-neutral-soft: rgba(226, 227, 229, 0.2);
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+  --md-sys-color-primary: #4dd6d4;
+  --md-sys-color-on-primary: #003738;
+  --md-sys-color-primary-container: #004f50;
+  --md-sys-color-on-primary-container: #6ff7f5;
+  --md-sys-color-secondary-container: #1e3535;
+  --md-sys-color-on-secondary-container: #cce8e7;
+  --md-sys-color-surface: #0e1515;
+  --md-sys-color-on-surface: #e1e3e2;
+  --md-sys-color-surface-container: #1a2020;
+  --md-sys-color-surface-container-low: #161b1b;
+  --md-sys-color-surface-container-high: #252b2b;
+  --md-sys-color-surface-variant: #3f4948;
+  --md-sys-color-on-surface-variant: #bfc8c7;
+  --md-sys-color-outline: #899392;
+  --md-sys-color-outline-variant: #3f4948;
+  --md-sys-color-error: #ffb4ab;
+  --md-sys-color-error-container: #93000a;
+  --md-sys-color-on-error: #690005;
+  --md-sys-color-on-error-container: #ffdad6;
+  --md-sys-elevation-level0: none;
+  --md-sys-elevation-level1: 0px 1px 3px 1px rgba(0, 0, 0, 0.4),
+    0px 1px 2px 0px rgba(0, 0, 0, 0.3);
+  --md-sys-elevation-level2: 0px 2px 6px 2px rgba(0, 0, 0, 0.45),
+    0px 1px 2px 0px rgba(0, 0, 0, 0.35);
+  --md-sys-elevation-level3: 0px 6px 10px rgba(0, 0, 0, 0.5),
+    0px 1px 18px rgba(0, 0, 0, 0.4),
+    0px 3px 5px rgba(0, 0, 0, 0.6);
+  --md-sys-elevation-level4: 0px 8px 12px rgba(0, 0, 0, 0.55),
+    0px 4px 20px rgba(0, 0, 0, 0.45),
+    0px 3px 6px rgba(0, 0, 0, 0.65);
+  --md-sys-typescale-body-large-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-body-medium-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-body-small-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-headline-medium-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-headline-small-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-label-large-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-title-large-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-title-medium-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --md-sys-typescale-title-small-font: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --app-border-subtle: #2b3131;
+  --app-border-strong: #3a4141;
+  --app-divider: #262c2c;
+  --app-focus-ring: rgba(77, 214, 212, 0.28);
+  --app-icon-muted: var(--md-sys-color-on-surface-variant);
+  --app-icon-danger: var(--md-sys-color-error);
+  --app-tonal-button-bg: var(--md-sys-color-primary-container);
+  --app-tonal-button-border: var(--md-sys-color-primary);
+  --app-tonal-button-text: var(--md-sys-color-on-primary-container);
+  --app-tonal-button-hover-bg: var(--md-sys-color-primary);
+  --app-tonal-button-hover-text: var(--md-sys-color-on-primary);
+  --app-table-header-bg: #1a2020;
+  --app-table-header-text: var(--md-sys-color-on-surface);
+  --app-table-subhead-text: var(--md-sys-color-on-surface-variant);
+  --app-table-sticky-bg: var(--md-sys-color-surface-container-low);
+  --app-table-row-hover: #232a2a;
+  --app-table-result-hover: rgba(77, 214, 212, 0.16);
+  --app-table-no-eval-bg: #1d2222;
+  --app-table-hierarchy-domain-bg: #123233;
+  --app-table-hierarchy-field-bg: #252035;
+  --app-table-hierarchy-competency-bg: #34261b;
+  --app-table-hierarchy-specific-bg: var(--md-sys-color-surface-container-low);
+  --app-table-search-border: #3a4444;
+  --app-table-search-focus-border: var(--md-sys-color-primary);
+  --app-select-dropdown-bg: var(--md-sys-color-surface-container-high);
+  --app-select-option-text: var(--md-sys-color-on-surface);
+  --app-select-option-hover-bg: #2f2a40;
+  --app-select-option-selected-bg: var(--md-sys-color-primary);
+  --app-select-option-selected-text: var(--md-sys-color-on-primary);
+  --app-status-success-container: #1d3a2b;
+  --app-status-success-border: #2f5f45;
+  --app-status-success-on: #9ddbc0;
+  --app-status-success-soft: rgba(157, 219, 192, 0.12);
+  --app-status-info-container: #12323d;
+  --app-status-info-border: #1f5464;
+  --app-status-info-on: #9cd7eb;
+  --app-status-info-soft: rgba(156, 215, 235, 0.12);
+  --app-status-warning-container: #3d2f12;
+  --app-status-warning-border: #5c4518;
+  --app-status-warning-on: #f2d58a;
+  --app-status-warning-soft: rgba(242, 213, 138, 0.12);
+  --app-status-danger-container: #3f1a1f;
+  --app-status-danger-border: #6b2a33;
+  --app-status-danger-on: #f7b4bd;
+  --app-status-danger-soft: rgba(247, 180, 189, 0.16);
+  --app-status-neutral-container: #2f3033;
+  --app-status-neutral-border: #45464a;
+  --app-status-neutral-on: #dadbe0;
+  --app-status-neutral-soft: rgba(218, 219, 224, 0.08);
+}
+
+:root:not([data-theme]) {
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    color-scheme: dark;
+    --md-sys-color-primary: #4dd6d4;
+    --md-sys-color-on-primary: #003738;
+    --md-sys-color-primary-container: #004f50;
+    --md-sys-color-on-primary-container: #6ff7f5;
+    --md-sys-color-secondary-container: #1e3535;
+    --md-sys-color-on-secondary-container: #cce8e7;
+    --md-sys-color-surface: #0e1515;
+    --md-sys-color-on-surface: #e1e3e2;
+    --md-sys-color-surface-container: #1a2020;
+    --md-sys-color-surface-container-low: #161b1b;
+    --md-sys-color-surface-container-high: #252b2b;
+    --md-sys-color-surface-variant: #3f4948;
+    --md-sys-color-on-surface-variant: #bfc8c7;
+    --md-sys-color-outline: #899392;
+    --md-sys-color-outline-variant: #3f4948;
+    --md-sys-color-error: #ffb4ab;
+    --md-sys-color-error-container: #93000a;
+    --md-sys-color-on-error: #690005;
+    --md-sys-color-on-error-container: #ffdad6;
+    --app-border-subtle: #2b3131;
+    --app-border-strong: #3a4141;
+    --app-divider: #262c2c;
+    --app-focus-ring: rgba(77, 214, 212, 0.28);
+    --app-icon-muted: var(--md-sys-color-on-surface-variant);
+    --app-icon-danger: var(--md-sys-color-error);
+    --app-tonal-button-bg: var(--md-sys-color-primary-container);
+    --app-tonal-button-border: var(--md-sys-color-primary);
+    --app-tonal-button-text: var(--md-sys-color-on-primary-container);
+    --app-tonal-button-hover-bg: var(--md-sys-color-primary);
+    --app-tonal-button-hover-text: var(--md-sys-color-on-primary);
+    --app-table-header-bg: #1a2020;
+    --app-table-header-text: var(--md-sys-color-on-surface);
+    --app-table-subhead-text: var(--md-sys-color-on-surface-variant);
+    --app-table-sticky-bg: var(--md-sys-color-surface-container-low);
+    --app-table-row-hover: #232a2a;
+    --app-table-result-hover: rgba(77, 214, 212, 0.16);
+    --app-table-no-eval-bg: #1d2222;
+    --app-table-hierarchy-domain-bg: #123233;
+    --app-table-hierarchy-field-bg: #252035;
+    --app-table-hierarchy-competency-bg: #34261b;
+    --app-table-hierarchy-specific-bg: var(--md-sys-color-surface-container-low);
+    --app-table-search-border: #3a4444;
+    --app-table-search-focus-border: var(--md-sys-color-primary);
+    --app-select-dropdown-bg: var(--md-sys-color-surface-container-high);
+    --app-select-option-text: var(--md-sys-color-on-surface);
+    --app-select-option-hover-bg: #2f2a40;
+    --app-select-option-selected-bg: var(--md-sys-color-primary);
+    --app-select-option-selected-text: var(--md-sys-color-on-primary);
+    --app-status-success-container: #1d3a2b;
+    --app-status-success-border: #2f5f45;
+    --app-status-success-on: #9ddbc0;
+    --app-status-success-soft: rgba(157, 219, 192, 0.12);
+    --app-status-info-container: #12323d;
+    --app-status-info-border: #1f5464;
+    --app-status-info-on: #9cd7eb;
+    --app-status-info-soft: rgba(156, 215, 235, 0.12);
+    --app-status-warning-container: #3d2f12;
+    --app-status-warning-border: #5c4518;
+    --app-status-warning-on: #f2d58a;
+    --app-status-warning-soft: rgba(242, 213, 138, 0.12);
+    --app-status-danger-container: #3f1a1f;
+    --app-status-danger-border: #6b2a33;
+    --app-status-danger-on: #f7b4bd;
+    --app-status-danger-soft: rgba(247, 180, 189, 0.16);
+    --app-status-neutral-container: #2f3033;
+    --app-status-neutral-border: #45464a;
+    --app-status-neutral-on: #dadbe0;
+    --app-status-neutral-soft: rgba(218, 219, 224, 0.08);
+  }
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -17,11 +338,15 @@ html {
     'Open Sans',
     'Helvetica Neue',
     sans-serif;
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
 }
 
 body {
   margin: 0;
   min-height: 100vh;
+  background: inherit;
+  color: inherit;
 }
 
 .visually-hidden {

--- a/src/views/CompetenciesView.vue
+++ b/src/views/CompetenciesView.vue
@@ -1956,7 +1956,7 @@ function exportFramework() {
   display: flex;
   flex-direction: column;
   height: 100vh;
-  background-color: #ffffff;
+  background-color: var(--md-sys-color-surface);
   position: relative;
 }
 
@@ -1972,7 +1972,7 @@ function exportFramework() {
 .tabs-container {
   position: sticky;
   top: 0;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   border-bottom: 1px solid var(--md-sys-color-outline-variant, #c4c7c5);
   z-index: 10;
 }
@@ -2105,7 +2105,7 @@ function exportFramework() {
 .old-page-title {
   font-size: 2rem;
   font-weight: 700;
-  color: #2c3e50;
+  color: var(--md-sys-color-on-surface);
   margin: 0;
   display: flex;
   align-items: center;
@@ -2113,7 +2113,7 @@ function exportFramework() {
 }
 
 .page-title .material-symbols-outlined {
-  color: #2563eb;
+  color: var(--md-sys-color-primary);
   font-size: 2rem;
 }
 
@@ -2121,12 +2121,12 @@ function exportFramework() {
   flex: 1;
   overflow-y: auto;
   padding: 24px 32px;
-  background-color: #ffffff;
+  background-color: var(--md-sys-color-surface);
 }
 
 /* Unified Card Styles for all views */
 .content-card {
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   margin: 0 0 8px 0; /* 8dp max padding between cards */
   border-radius: 12px; /* 12dp corner radius */
   border: 1px solid var(--md-sys-color-outline-variant, #c4c7c5);
@@ -2173,14 +2173,14 @@ function exportFramework() {
   left: 1rem;
   top: 50%;
   transform: translateY(-50%);
-  color: #6b7280;
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 20px;
 }
 
 .search-input {
   width: 100%;
   padding: 0.75rem 1rem 0.75rem 2.5rem;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: 0.5rem;
   font-size: 1rem;
   transition: border-color 0.2s;
@@ -2188,7 +2188,7 @@ function exportFramework() {
 
 .search-input:focus {
   outline: none;
-  border-color: #2563eb;
+  border-color: var(--md-sys-color-primary);
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
 }
 
@@ -2213,7 +2213,7 @@ function exportFramework() {
 }
 
 .node-content:hover {
-  background-color: #f8f9fa;
+  background-color: var(--md-sys-color-surface-container-high);
 }
 
 .node-icon {
@@ -2223,14 +2223,14 @@ function exportFramework() {
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  color: #6b7280;
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 18px;
 }
 
 .node-label {
   flex: 1;
   min-width: 0;
-  color: #111827;
+  color: var(--md-sys-color-on-surface);
 }
 
 .node-actions {
@@ -2249,22 +2249,22 @@ function exportFramework() {
 /* Niveau 1 - Domaines */
 .domain-node .node-content {
   padding: 12px 16px;
-  background-color: #ffffff;
+  background-color: var(--md-sys-color-surface);
 }
 
 .domain-node .node-content:hover {
-  background-color: #f8f9fa;
+  background-color: var(--md-sys-color-surface-container-high);
 }
 
 .domain-label {
   font-size: 18px;
   font-weight: 600;
-  color: #111827;
+  color: var(--md-sys-color-on-surface);
   letter-spacing: -0.025em;
 }
 
 .domain-node .node-icon {
-  color: #4b5563;
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 20px;
 }
 
@@ -2280,12 +2280,12 @@ function exportFramework() {
 .field-label {
   font-size: 16px;
   font-weight: 500;
-  color: #374151;
+  color: var(--md-sys-color-on-surface);
 }
 
 .field-node .node-icon {
   font-size: 18px;
-  color: #6b7280;
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 /* Niveau 3 - Compétences */
@@ -2300,7 +2300,7 @@ function exportFramework() {
 .competency-label {
   font-size: 14px;
   font-weight: 500;
-  color: #4b5563;
+  color: var(--md-sys-color-on-surface-variant);
   line-height: 1.4;
 }
 
@@ -2321,13 +2321,13 @@ function exportFramework() {
 .specific-competency-label {
   font-size: 13px;
   font-weight: 400;
-  color: #6b7280;
+  color: var(--md-sys-color-on-surface-variant);
   line-height: 1.5;
 }
 
 .specific-competency-node .node-icon {
   font-size: 14px;
-  color: #9ca3af;
+  color: color-mix(in srgb, var(--md-sys-color-on-surface) 40%, transparent);
 }
 
 /* Conteneurs pour les enfants */
@@ -2352,7 +2352,7 @@ function exportFramework() {
   justify-content: center;
   transition: all 0.2s cubic-bezier(0.2, 0, 0, 1);
   background: transparent;
-  color: #49454f;
+  color: var(--md-sys-color-on-surface-variant);
   position: relative;
 }
 
@@ -2375,17 +2375,17 @@ function exportFramework() {
 }
 
 .action-btn:hover::before {
-  background: #49454f;
+  background: var(--md-sys-color-on-surface-variant);
   opacity: 0.08;
 }
 
 .action-btn:focus::before {
-  background: #49454f;
+  background: var(--md-sys-color-on-surface-variant);
   opacity: 0.12;
 }
 
 .action-btn:active::before {
-  background: #49454f;
+  background: var(--md-sys-color-on-surface-variant);
   opacity: 0.12;
 }
 
@@ -2394,20 +2394,20 @@ function exportFramework() {
 }
 
 .delete-action:hover {
-  color: #ba1a1a;
+  color: var(--md-sys-color-error);
 }
 
 .delete-action:hover::before {
-  background: #ba1a1a;
+  background: var(--md-sys-color-error);
   opacity: 0.08;
 }
 
 .delete-action:focus {
-  color: #ba1a1a;
+  color: var(--md-sys-color-error);
 }
 
 .delete-action:focus::before {
-  background: #ba1a1a;
+  background: var(--md-sys-color-error);
   opacity: 0.12;
 }
 
@@ -2424,8 +2424,8 @@ function exportFramework() {
   max-width: none;
   padding: 0 16px;
 
-  background: #eaddff;
-  color: #21005d;
+  background: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-on-primary-container);
   border: none;
   border-radius: 16px;
 
@@ -2468,7 +2468,7 @@ function exportFramework() {
   left: 0;
   right: 0;
   bottom: 0;
-  background: #21005d;
+  background: var(--md-sys-color-on-primary-container);
   opacity: 0;
   transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1);
   border-radius: inherit;
@@ -2538,7 +2538,7 @@ function exportFramework() {
 }
 
 .dialog-container {
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   border-radius: 28px;
   box-shadow:
     0px 3px 1px -2px rgba(0, 0, 0, 0.2),
@@ -2577,13 +2577,13 @@ function exportFramework() {
 .dialog-icon {
   width: 24px;
   height: 24px;
-  color: #625b71;
+  color: var(--md-sys-color-on-surface-variant);
   flex-shrink: 0;
   margin-top: 2px;
 }
 
 .alert-icon {
-  color: #ba1a1a;
+  color: var(--md-sys-color-error);
 }
 
 .dialog-headline {
@@ -2591,7 +2591,7 @@ function exportFramework() {
   font-size: 24px;
   font-weight: 400;
   line-height: 32px;
-  color: #1c1b1f;
+  color: var(--md-sys-color-on-surface);
   margin: 0;
   flex: 1;
 }
@@ -2605,7 +2605,7 @@ function exportFramework() {
   font-size: 14px;
   font-weight: 400;
   line-height: 20px;
-  color: #49454f;
+  color: var(--md-sys-color-on-surface-variant);
   margin: 0 0 16px 0;
 }
 
@@ -2614,7 +2614,7 @@ function exportFramework() {
 }
 
 .warning-text {
-  color: #ba1a1a;
+  color: var(--md-sys-color-error);
 }
 
 .dialog-form {
@@ -2635,7 +2635,7 @@ function exportFramework() {
   font-size: 12px;
   font-weight: 400;
   line-height: 16px;
-  color: #49454f;
+  color: var(--md-sys-color-on-surface-variant);
   margin-bottom: 8px;
   transition: color 0.2s cubic-bezier(0.2, 0, 0, 1);
 }
@@ -2647,7 +2647,7 @@ function exportFramework() {
   font-size: 16px;
   font-weight: 400;
   line-height: 24px;
-  color: #1c1b1f;
+  color: var(--md-sys-color-on-surface);
   background: transparent;
   border: none;
   outline: none;
@@ -2659,13 +2659,13 @@ function exportFramework() {
 
 .text-field-input::placeholder,
 .text-field-textarea::placeholder {
-  color: #49454f;
+  color: var(--md-sys-color-on-surface-variant);
   opacity: 0.6;
 }
 
 .text-field-underline {
   height: 1px;
-  background: #79747e;
+  background: var(--md-sys-color-outline);
   transition: all 0.2s cubic-bezier(0.2, 0, 0, 1);
   position: relative;
 }
@@ -2677,7 +2677,7 @@ function exportFramework() {
   left: 50%;
   right: 50%;
   height: 2px;
-  background: #6750a4;
+  background: var(--md-sys-color-primary);
   transition: all 0.2s cubic-bezier(0.2, 0, 0, 1);
 }
 
@@ -2692,7 +2692,7 @@ function exportFramework() {
 .text-field-textarea:focus ~ .text-field-label,
 .text-field-select:focus ~ .text-field-label,
 .text-field:focus-within .text-field-label {
-  color: #6750a4;
+  color: var(--md-sys-color-primary);
 }
 
 .text-field-select {
@@ -2701,9 +2701,9 @@ function exportFramework() {
   font-family: 'Roboto', sans-serif;
   font-size: 16px;
   line-height: 24px;
-  color: #1c1b1f;
-  background: #ffffff;
-  border: 1px solid #79747e;
+  color: var(--md-sys-color-on-surface);
+  background: var(--md-sys-color-surface);
+  border: 1px solid var(--md-sys-color-outline);
   border-radius: 4px;
   cursor: pointer;
   transition: all 0.2s cubic-bezier(0.2, 0, 0, 1);
@@ -2711,31 +2711,31 @@ function exportFramework() {
 
 .text-field-select:focus {
   outline: none;
-  border-color: #6750a4;
-  box-shadow: 0 0 0 1px #6750a4;
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 1px var(--md-sys-color-primary);
 }
 
 .text-field-select:hover {
-  border-color: #49454f;
+  border-color: var(--md-sys-color-on-surface-variant);
 }
 
 /* Styles pour l'affichage du contexte dans le modal */
 .context-info {
-  background: #f8f9fa;
+  background: var(--md-sys-color-surface-container-high);
   border-radius: 8px;
   padding: 12px;
   margin-top: 16px;
-  border-left: 3px solid #e5e7eb;
+  border-left: 3px solid var(--md-sys-color-outline-variant);
 }
 
 .context-info p {
   margin: 4px 0;
   font-size: 13px;
-  color: #6b7280;
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .context-info strong {
-  color: #374151;
+  color: var(--md-sys-color-on-surface);
   font-weight: 500;
 }
 
@@ -2752,7 +2752,7 @@ function exportFramework() {
   font-size: 14px;
   font-weight: 500;
   line-height: 20px;
-  color: #6750a4;
+  color: var(--md-sys-color-primary);
   background: transparent;
   border: none;
   border-radius: 20px;
@@ -2771,7 +2771,7 @@ function exportFramework() {
   left: 0;
   right: 0;
   bottom: 0;
-  background: #6750a4;
+  background: var(--md-sys-color-primary);
   opacity: 0;
   transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1);
 }
@@ -2793,8 +2793,8 @@ function exportFramework() {
   font-size: 14px;
   font-weight: 500;
   line-height: 20px;
-  color: #ffffff;
-  background: #6750a4;
+  color: var(--md-sys-color-on-primary);
+  background: var(--md-sys-color-primary);
   border: none;
   border-radius: 20px;
   padding: 10px 24px;
@@ -2815,7 +2815,7 @@ function exportFramework() {
   left: 0;
   right: 0;
   bottom: 0;
-  background: #ffffff;
+  background: var(--md-sys-color-on-primary);
   opacity: 0;
   transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1);
 }
@@ -2833,12 +2833,12 @@ function exportFramework() {
 }
 
 .filled-button.destructive {
-  background: #ba1a1a;
-  color: #ffffff;
+  background: var(--md-sys-color-error);
+  color: var(--md-sys-color-on-error);
 }
 
 .filled-button.destructive::before {
-  background: #ffffff;
+  background: var(--md-sys-color-on-error);
 }
 
 /* Material 3 Extended FAB Specifications */
@@ -3156,13 +3156,13 @@ function exportFramework() {
   margin: 0 0 8px 0;
   font-size: 18px;
   font-weight: 600;
-  color: #1f2937;
+  color: var(--md-sys-color-on-surface);
   font-family: 'Roboto', sans-serif;
 }
 
 .section-description {
   margin: 0 0 16px 0;
-  color: #6b7280;
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 14px;
   font-family: 'Roboto', sans-serif;
   line-height: 1.5;
@@ -3175,8 +3175,8 @@ function exportFramework() {
 }
 
 .type-card {
-  background: #ffffff;
-  border: 1px solid #e5e7eb;
+  background: var(--md-sys-color-surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: 12px;
   padding: 20px;
   transition: all 0.2s cubic-bezier(0.2, 0, 0, 1);
@@ -3184,7 +3184,7 @@ function exportFramework() {
 
 .type-card:hover {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  border-color: #d1d5db;
+  border-color: var(--md-sys-color-outline-variant);
   transform: translateY(-2px);
 }
 
@@ -3199,7 +3199,7 @@ function exportFramework() {
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: #1f2937;
+  color: var(--md-sys-color-on-surface);
   font-family: 'Roboto', sans-serif;
 }
 
@@ -3211,7 +3211,7 @@ function exportFramework() {
 .type-label {
   font-size: 12px;
   font-weight: 500;
-  color: #6b7280;
+  color: var(--md-sys-color-on-surface-variant);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-family: 'Roboto', sans-serif;
@@ -3225,8 +3225,8 @@ function exportFramework() {
 }
 
 .value-chip {
-  background: #eaddff;
-  color: #21005d;
+  background: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-on-primary-container);
   padding: 6px 12px;
   border-radius: 16px;
   font-size: 12px;
@@ -3243,9 +3243,9 @@ function exportFramework() {
 
 .pivot-value {
   font-size: 12px;
-  color: #49454f;
+  color: var(--md-sys-color-on-surface-variant);
   font-weight: 500;
-  background: #f7f2fa;
+  background: var(--md-sys-color-surface-container-high);
   padding: 4px 8px;
   border-radius: 8px;
   min-width: 40px;
@@ -3314,7 +3314,7 @@ function exportFramework() {
 }
 
 .import-zone {
-  border: 2px dashed #d1d5db;
+  border: 2px dashed var(--md-sys-color-outline-variant);
   border-radius: 8px;
   padding: 24px;
   text-align: center;
@@ -3322,14 +3322,14 @@ function exportFramework() {
 }
 
 .import-zone:hover {
-  border-color: #9ca3af;
-  background-color: #f8f9fa;
+  border-color: color-mix(in srgb, var(--md-sys-color-on-surface) 40%, transparent);
+  background-color: var(--md-sys-color-surface-container-high);
 }
 
 .import-zone input[type="file"] {
   width: 100%;
   padding: 8px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: 4px;
 }
 
@@ -3338,7 +3338,7 @@ function exportFramework() {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  background: #6750a4;
+  background: var(--md-sys-color-primary);
   color: white;
   border: none;
   border-radius: 20px;
@@ -3361,7 +3361,7 @@ function exportFramework() {
   left: 0;
   right: 0;
   bottom: 0;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   opacity: 0;
   transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1);
 }
@@ -3389,7 +3389,7 @@ function exportFramework() {
   border-radius: 50%;
   cursor: pointer;
   transition: all 0.2s cubic-bezier(0.2, 0, 0, 1);
-  color: #49454f;
+  color: var(--md-sys-color-on-surface-variant);
   position: relative;
 }
 
@@ -3407,17 +3407,17 @@ function exportFramework() {
 }
 
 .icon-btn:hover::before {
-  background: #49454f;
+  background: var(--md-sys-color-on-surface-variant);
   opacity: 0.08;
 }
 
 .icon-btn:focus::before {
-  background: #49454f;
+  background: var(--md-sys-color-on-surface-variant);
   opacity: 0.12;
 }
 
 .icon-btn:active::before {
-  background: #49454f;
+  background: var(--md-sys-color-on-surface-variant);
   opacity: 0.12;
 }
 
@@ -3428,7 +3428,7 @@ function exportFramework() {
 /* Styles pour la modale des types de résultats */
 .field-helper-text {
   font-size: 12px;
-  color: #6b7280;
+  color: var(--md-sys-color-on-surface-variant);
   margin-top: 4px;
   font-family: 'Roboto', sans-serif;
 }
@@ -3436,9 +3436,9 @@ function exportFramework() {
 .values-preview {
   margin-top: 16px;
   padding: 12px;
-  background: #f8f9fa;
+  background: var(--md-sys-color-surface-container-high);
   border-radius: 8px;
-  border-left: 3px solid #6750a4;
+  border-left: 3px solid var(--md-sys-color-primary);
 }
 
 .values-preview .type-label {
@@ -3446,7 +3446,7 @@ function exportFramework() {
   margin-bottom: 8px;
   font-size: 12px;
   font-weight: 500;
-  color: #6b7280;
+  color: var(--md-sys-color-on-surface-variant);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-family: 'Roboto', sans-serif;
@@ -3465,7 +3465,7 @@ function exportFramework() {
   left: 0;
   right: 0;
   bottom: 0;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   z-index: 1000;
   display: flex;
   flex-direction: column;
@@ -3486,8 +3486,8 @@ function exportFramework() {
 /* App Bar */
 .fullscreen-app-bar {
   height: 64px;
-  background: #ffffff;
-  border-bottom: 1px solid #e7e0ec;
+  background: var(--md-sys-color-surface);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
   display: flex;
   align-items: center;
   padding: 0 4px;
@@ -3510,7 +3510,7 @@ function exportFramework() {
   font-size: 22px;
   font-weight: 400;
   line-height: 28px;
-  color: #1d1b20;
+  color: var(--md-sys-color-on-surface);
   margin: 0;
 }
 
@@ -3534,7 +3534,7 @@ function exportFramework() {
 .fullscreen-content {
   flex: 1;
   overflow-y: auto;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
 }
 
 .fullscreen-body {
@@ -3556,7 +3556,7 @@ function exportFramework() {
   font-size: 24px;
   font-weight: 400;
   line-height: 32px;
-  color: #1d1b20;
+  color: var(--md-sys-color-on-surface);
   margin: 0 0 8px 0;
 }
 
@@ -3565,7 +3565,7 @@ function exportFramework() {
   font-size: 16px;
   font-weight: 400;
   line-height: 24px;
-  color: #49454f;
+  color: var(--md-sys-color-on-surface-variant);
   margin: 0 0 24px 0;
 }
 
@@ -3588,7 +3588,7 @@ function exportFramework() {
   font-size: 16px;
   font-weight: 400;
   line-height: 24px;
-  color: #1d1b20;
+  color: var(--md-sys-color-on-surface);
   background: transparent;
   border: none;
   outline: none;
@@ -3609,7 +3609,7 @@ function exportFramework() {
   font-size: 16px;
   font-weight: 400;
   line-height: 24px;
-  color: #1d1b20;
+  color: var(--md-sys-color-on-surface);
   background: transparent;
   border: none;
   outline: none;
@@ -3634,8 +3634,8 @@ function exportFramework() {
   font-size: 16px;
   font-weight: 400;
   line-height: 24px;
-  color: #49454f;
-  background: #ffffff;
+  color: var(--md-sys-color-on-surface-variant);
+  background: var(--md-sys-color-surface);
   padding: 0 4px;
   pointer-events: none;
   transition: all 0.2s cubic-bezier(0.2, 0, 0, 1);
@@ -3652,7 +3652,7 @@ function exportFramework() {
   top: 0;
   font-size: 12px;
   line-height: 16px;
-  color: #6750a4;
+  color: var(--md-sys-color-primary);
   transform: translateY(-50%);
 }
 
@@ -3668,7 +3668,7 @@ function exportFramework() {
 
 .text-field-outline-start {
   width: 12px;
-  border: 1px solid #79747e;
+  border: 1px solid var(--md-sys-color-outline);
   border-right: none;
   border-radius: 4px 0 0 4px;
 }
@@ -3676,8 +3676,8 @@ function exportFramework() {
 .text-field-outline-notch {
   flex: 1;
   display: flex;
-  border-top: 1px solid #79747e;
-  border-bottom: 1px solid #79747e;
+  border-top: 1px solid var(--md-sys-color-outline);
+  border-bottom: 1px solid var(--md-sys-color-outline);
 }
 
 .text-field-outline-leading {
@@ -3689,13 +3689,13 @@ function exportFramework() {
 
 .text-field-outline-trailing {
   flex: 1;
-  border-top: 1px solid #79747e;
-  border-bottom: 1px solid #79747e;
+  border-top: 1px solid var(--md-sys-color-outline);
+  border-bottom: 1px solid var(--md-sys-color-outline);
 }
 
 .text-field-outline-end {
   width: 12px;
-  border: 1px solid #79747e;
+  border: 1px solid var(--md-sys-color-outline);
   border-left: none;
   border-radius: 0 4px 4px 0;
 }
@@ -3709,7 +3709,7 @@ function exportFramework() {
 .text-field-select-outlined:focus ~ .text-field-outline .text-field-outline-start,
 .text-field-select-outlined:focus ~ .text-field-outline .text-field-outline-end,
 .text-field-select-outlined:focus ~ .text-field-outline .text-field-outline-trailing {
-  border-color: #6750a4;
+  border-color: var(--md-sys-color-primary);
   border-width: 2px;
 }
 
@@ -3729,8 +3729,8 @@ function exportFramework() {
 
 /* Preview */
 .preview-container {
-  background: #ffffff;
-  border: 1px solid #e7e0ec;
+  background: var(--md-sys-color-surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: 12px;
   padding: 24px;
 }
@@ -3742,20 +3742,20 @@ function exportFramework() {
 }
 
 .preview-chip {
-  background: #e8def8;
-  color: #1d1b20;
+  background: var(--md-sys-color-surface-variant);
+  color: var(--md-sys-color-on-surface);
   padding: 8px 16px;
   border-radius: 8px;
   font-size: 14px;
   font-weight: 500;
   font-family: 'Roboto', sans-serif;
-  border: 1px solid #cac4d0;
+  border: 1px solid var(--md-sys-color-outline-variant);
 }
 
 /* Context Section */
 .context-container {
-  background: #f8f9fa;
-  border: 1px solid #e7e0ec;
+  background: var(--md-sys-color-surface-container-high);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: 12px;
   padding: 20px;
 }
@@ -3765,7 +3765,7 @@ function exportFramework() {
   align-items: center;
   gap: 16px;
   padding: 12px 0;
-  border-bottom: 1px solid #e7e0ec;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
 }
 
 .context-item:last-child {
@@ -3778,7 +3778,7 @@ function exportFramework() {
 }
 
 .context-icon {
-  color: #6750a4;
+  color: var(--md-sys-color-primary);
   font-size: 24px;
   flex-shrink: 0;
 }
@@ -3794,7 +3794,7 @@ function exportFramework() {
   font-family: 'Roboto', sans-serif;
   font-size: 12px;
   font-weight: 500;
-  color: #6b7280;
+  color: var(--md-sys-color-on-surface-variant);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -3803,7 +3803,7 @@ function exportFramework() {
   font-family: 'Roboto', sans-serif;
   font-size: 16px;
   font-weight: 500;
-  color: #1d1b20;
+  color: var(--md-sys-color-on-surface);
   line-height: 24px;
 }
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -353,7 +353,7 @@ watch(isLoading, (newLoading) => {
 /* Evaluation Meta Section */
 .evaluation-meta-section {
   padding: 16px 24px;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   border-radius: 0 0 12px 12px;
   margin-bottom: 24px;
 }
@@ -650,7 +650,7 @@ watch(isLoading, (newLoading) => {
   color: var(--md-sys-color-on-surface-variant, #49454f);
   pointer-events: none;
   transition: all 0.2s ease;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   padding: 0 4px;
   z-index: 2;
 }
@@ -662,7 +662,7 @@ watch(isLoading, (newLoading) => {
   left: 12px;
   font-size: var(--md-sys-typescale-body-small-size, 12px);
   color: var(--md-sys-color-primary, #6750a4);
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   padding: 0 4px;
 }
 

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -132,7 +132,7 @@ const handleConsoleLogoToggle = (event: Event) => {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
 }
 
 .settings-content {
@@ -272,7 +272,7 @@ const handleConsoleLogoToggle = (event: Event) => {
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   box-shadow:
     0px 1px 3px rgba(0, 0, 0, 0.15),
     0px 1px 2px rgba(0, 0, 0, 0.3);
@@ -287,7 +287,7 @@ const handleConsoleLogoToggle = (event: Event) => {
 
 .md3-switch input:checked + .md3-switch__track .md3-switch__handle {
   transform: translateX(20px);
-  background: #ffffff;
+  background: var(--md-sys-color-on-primary);
 }
 
 .md3-switch input:focus-visible + .md3-switch__track {

--- a/src/views/StudentsView.vue
+++ b/src/views/StudentsView.vue
@@ -331,7 +331,7 @@ const closeModal = () => {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
 }
 
 .students-content {
@@ -729,7 +729,7 @@ const closeModal = () => {
 
 /* Basic Dialog - 280dp minimum width, 560dp maximum */
 .dialog-container {
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   border-radius: 28px;
   box-shadow:
     0px 3px 1px -2px rgba(0, 0, 0, 0.2),
@@ -770,13 +770,13 @@ const closeModal = () => {
 .dialog-icon {
   width: 24px;
   height: 24px;
-  color: #625b71;
+  color: var(--md-sys-color-on-surface-variant);
   flex-shrink: 0;
   margin-top: 2px;
 }
 
 .alert-icon {
-  color: #ba1a1a;
+  color: var(--md-sys-color-error);
 }
 
 .dialog-headline {
@@ -971,8 +971,8 @@ const closeModal = () => {
   font-size: 14px;
   font-weight: 500;
   line-height: 20px;
-  color: #ffffff;
-  background: #6750a4;
+  color: var(--md-sys-color-on-primary);
+  background: var(--md-sys-color-primary);
   border: none;
   border-radius: 20px;
   padding: 10px 24px;
@@ -993,7 +993,7 @@ const closeModal = () => {
   left: 0;
   right: 0;
   bottom: 0;
-  background: #ffffff;
+  background: var(--md-sys-color-on-primary);
   opacity: 0;
   transition: opacity 0.2s cubic-bezier(0.2, 0, 0, 1);
 }
@@ -1011,12 +1011,12 @@ const closeModal = () => {
 }
 
 .filled-button.destructive {
-  background: #ba1a1a;
-  color: #ffffff;
+  background: var(--md-sys-color-error);
+  color: var(--md-sys-color-on-error);
 }
 
 .filled-button.destructive::before {
-  background: #ffffff;
+  background: var(--md-sys-color-on-error);
 }
 
 /* Styles pour les boutons disabled */
@@ -1266,7 +1266,7 @@ const closeModal = () => {
 
 /* Preview Container */
 .preview-container {
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   border: 1px solid var(--md-sys-color-outline-variant, #c4c7c5);
   border-radius: var(--md-sys-shape-corner-medium, 12px);
   padding: 24px;
@@ -1347,7 +1347,7 @@ const closeModal = () => {
   font-weight: var(--md-sys-typescale-body-large-weight, 400);
   line-height: var(--md-sys-typescale-body-large-line-height, 24px);
   color: var(--md-sys-color-on-surface-variant, #49454f);
-  background: #ffffff;
+  background: var(--md-sys-color-surface);
   padding: 0 4px;
   pointer-events: none;
   transition: all 0.2s cubic-bezier(0.2, 0, 0, 1);


### PR DESCRIPTION
## Summary
- add app-specific CSS custom properties for surfaces, focus states, selects, and status palettes in the global stylesheet so both light and dark themes share a single source of truth
- restyle the evaluation table to rely on the new tokens for headers, sticky hierarchy columns, result badges, and inline editors across light/dark mode
- update the evaluation persistence status component to consume the shared status tokens for badges, actions, and cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc6c82bcbc83209afe3d2a498ac23a