### PR TITLE
test: add business coverage for evaluation workflows

### DIFF
--- a/docs/tested-features.md
+++ b/docs/tested-features.md
@@ -1,0 +1,23 @@
+# Fonctionnalités couvertes par les tests unitaires
+
+## Gestion des évaluations
+- Chargement des évaluations depuis Supabase et sélection de l'évaluation active (`tests/unit/evaluationStore.spec.ts`)
+- Création d'une évaluation et mise à jour de l'état courant (`tests/unit/evaluationStore.spec.ts`)
+- Modification et suppression d'une évaluation en synchronisation avec le store (`tests/unit/evaluationStore.spec.ts`)
+
+## Gestion des élèves
+- Ajout d'un élève via le service Supabase et mise à jour du catalogue (`tests/unit/studentsStore.spec.ts`)
+- Modification d'un élève avec recalcul du nom affiché (`tests/unit/studentsStore.spec.ts`)
+- Suppression d'un élève et maintien de la cohérence du store (`tests/unit/studentsStore.spec.ts`)
+
+## Gestion du référentiel de compétences
+- Création, mise à jour et suppression d'une compétence dans le référentiel (`tests/unit/studentsStore.spec.ts`)
+
+## Export PDF des analyses
+- Génération d'un PDF pour un graphique élève individuel avec `html2canvas` et `jsPDF` (`tests/unit/pdfExport.spec.ts`)
+- Génération d'un PDF multi-pages pour l'ensemble des graphiques élèves (`tests/unit/pdfExport.spec.ts`)
+
+## Calculs pour les graphiques d'analyse
+- Normalisation des résultats d'évaluation (numériques et qualitatifs) (`tests/unit/pivotAnalysisService.spec.ts`)
+- Agrégation statistique et regroupement des résultats pour alimenter les graphiques (`tests/unit/pivotAnalysisService.spec.ts`)
+- Dénormalisation des valeurs pivot pour retrouver l'échelle d'origine (`tests/unit/pivotAnalysisService.spec.ts`)

--- a/tests/unit/evaluationStore.spec.ts
+++ b/tests/unit/evaluationStore.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Evaluation } from '@/types/evaluation'
+
+const mockSupabaseEvaluationsService = {
+  getEvaluations: vi.fn<[], Promise<Evaluation[]>>(),
+  createEvaluation: vi.fn<[], Promise<Evaluation | null>>(),
+  updateEvaluation: vi.fn<[], Promise<Evaluation | null>>(),
+  deleteEvaluation: vi.fn<[], Promise<boolean>>()
+}
+
+vi.mock('@/services/supabaseEvaluationsService', () => ({
+  supabaseEvaluationsService: mockSupabaseEvaluationsService
+}))
+
+const sampleEvaluation = {
+  id: 'eval-001',
+  name: 'Évaluation initiale',
+  description: 'Évaluation de référence',
+  frameworkId: 'framework-1',
+  classId: 'class-a',
+  createdAt: '2025-01-01T10:00:00.000Z',
+  results: []
+} satisfies Evaluation
+
+describe('useEvaluationStore', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('charge les évaluations et définit la première comme évaluation courante', async () => {
+    mockSupabaseEvaluationsService.getEvaluations.mockResolvedValue([sampleEvaluation])
+
+    const { useEvaluationStore } = await import('@/stores/evaluationStore')
+    const store = useEvaluationStore()
+
+    await store.loadEvaluations()
+
+    expect(store.allEvaluations.value).toHaveLength(1)
+    expect(store.currentEvaluation.value.id).toBe(sampleEvaluation.id)
+  })
+
+  it('ajoute une évaluation et la définit comme évaluation courante', async () => {
+    mockSupabaseEvaluationsService.createEvaluation.mockResolvedValue(sampleEvaluation)
+
+    const { useEvaluationStore } = await import('@/stores/evaluationStore')
+    const store = useEvaluationStore()
+
+    const created = await store.addEvaluation({
+      name: sampleEvaluation.name,
+      description: sampleEvaluation.description,
+      frameworkId: sampleEvaluation.frameworkId,
+      classId: sampleEvaluation.classId
+    })
+
+    expect(created).toEqual(sampleEvaluation)
+    expect(store.allEvaluations.value.find(evaluation => evaluation.id === sampleEvaluation.id)).toBeDefined()
+    expect(store.currentEvaluation.value.id).toBe(sampleEvaluation.id)
+  })
+
+  it('met à jour une évaluation existante et synchronise le store', async () => {
+    const updatedEvaluation: Evaluation = { ...sampleEvaluation, name: 'Évaluation mise à jour' }
+
+    mockSupabaseEvaluationsService.createEvaluation.mockResolvedValue(sampleEvaluation)
+    mockSupabaseEvaluationsService.updateEvaluation.mockResolvedValue(updatedEvaluation)
+
+    const { useEvaluationStore } = await import('@/stores/evaluationStore')
+    const store = useEvaluationStore()
+
+    await store.addEvaluation({
+      name: sampleEvaluation.name,
+      description: sampleEvaluation.description,
+      frameworkId: sampleEvaluation.frameworkId,
+      classId: sampleEvaluation.classId
+    })
+
+    const result = await store.updateEvaluation(sampleEvaluation.id, { name: updatedEvaluation.name })
+
+    expect(result).toEqual(updatedEvaluation)
+    expect(store.allEvaluations.value[0].name).toBe('Évaluation mise à jour')
+    expect(store.currentEvaluation.value.name).toBe('Évaluation mise à jour')
+  })
+
+  it('supprime une évaluation et met à jour la sélection courante', async () => {
+    mockSupabaseEvaluationsService.createEvaluation.mockResolvedValue(sampleEvaluation)
+    mockSupabaseEvaluationsService.deleteEvaluation.mockResolvedValue(true)
+
+    const { useEvaluationStore } = await import('@/stores/evaluationStore')
+    const store = useEvaluationStore()
+
+    await store.addEvaluation({
+      name: sampleEvaluation.name,
+      description: sampleEvaluation.description,
+      frameworkId: sampleEvaluation.frameworkId,
+      classId: sampleEvaluation.classId
+    })
+
+    const success = await store.deleteEvaluation(sampleEvaluation.id)
+
+    expect(success).toBe(true)
+    expect(store.allEvaluations.value.find(evaluation => evaluation.id === sampleEvaluation.id)).toBeUndefined()
+    expect(store.currentEvaluation.value.id).not.toBe(sampleEvaluation.id)
+  })
+})

--- a/tests/unit/pdfExport.spec.ts
+++ b/tests/unit/pdfExport.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AnalysisView from '@/views/AnalysisView.vue'
+
+const mockPdfInstances: any[] = []
+
+const mockJsPDF = vi.fn(() => {
+  const instance = {
+    internal: {
+      pageSize: {
+        getWidth: vi.fn(() => 297),
+        getHeight: vi.fn(() => 210)
+      }
+    },
+    setFontSize: vi.fn(),
+    text: vi.fn(),
+    addImage: vi.fn(),
+    addPage: vi.fn(),
+    save: vi.fn()
+  }
+  mockPdfInstances.push(instance)
+  return instance
+})
+
+const mockHtml2Canvas = vi.fn(async () => ({
+  width: 800,
+  height: 600,
+  toDataURL: vi.fn(() => 'data:image/png;base64,mock')
+}))
+
+vi.mock('jspdf', () => ({ jsPDF: mockJsPDF }))
+vi.mock('html2canvas', () => ({ default: mockHtml2Canvas }))
+
+vi.mock('@/services/supabaseStudentsService', () => ({
+  supabaseStudentsService: {
+    getAllStudents: vi.fn(async () => []),
+    createStudent: vi.fn(),
+    updateStudent: vi.fn(),
+    deleteStudent: vi.fn()
+  }
+}))
+
+vi.mock('@/services/supabaseCompetenciesService', () => ({
+  supabaseCompetenciesService: {
+    getOrCreateDefaultFramework: vi.fn(async () => ({ id: 'framework-1', name: 'Mock', version: '1.0' })),
+    getAllDomains: vi.fn(async () => []),
+    updateSpecificCompetency: vi.fn()
+  }
+}))
+
+describe('Fonctions d\'export PDF', () => {
+  let alertSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    mockJsPDF.mockClear()
+    mockHtml2Canvas.mockClear()
+    mockPdfInstances.length = 0
+    document.body.innerHTML = ''
+    alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    alertSpy.mockRestore()
+  })
+
+  it('exporte le graphique individuel en PDF', async () => {
+    const chartElement = document.createElement('div')
+    chartElement.className = 'chart-container'
+    document.body.appendChild(chartElement)
+
+    const wrapper = mount(AnalysisView, {
+      global: {
+        stubs: {
+          CenterAppBar: { template: '<div />' },
+          AnalysisTabs: { template: '<div><slot /></div>' },
+          DashboardView: { template: '<div />' },
+          StudentAnalysisView: { template: '<div />' }
+        }
+      }
+    })
+
+    await wrapper.vm.exportStudentChart()
+
+    expect(mockHtml2Canvas).toHaveBeenCalledWith(chartElement, expect.objectContaining({
+      backgroundColor: '#ffffff',
+      scale: 2,
+      useCORS: true
+    }))
+    expect(mockJsPDF).toHaveBeenCalledTimes(1)
+    const instance = mockPdfInstances[0]
+    expect(instance.addImage).toHaveBeenCalled()
+    expect(instance.save).toHaveBeenCalled()
+  })
+
+  it('exporte tous les graphiques élèves en PDF multi-pages', async () => {
+    const firstChart = document.createElement('div')
+    firstChart.className = 'chart-container'
+    const secondChart = document.createElement('div')
+    secondChart.className = 'chart-container'
+    document.body.append(firstChart, secondChart)
+
+    const wrapper = mount(AnalysisView, {
+      global: {
+        stubs: {
+          CenterAppBar: { template: '<div />' },
+          AnalysisTabs: { template: '<div><slot /></div>' },
+          DashboardView: { template: '<div />' },
+          StudentAnalysisView: { template: '<div />' }
+        }
+      }
+    })
+
+    await wrapper.vm.exportAllStudents()
+
+    expect(mockHtml2Canvas).toHaveBeenCalledTimes(2)
+    expect(mockJsPDF).toHaveBeenCalledTimes(1)
+    const instance = mockPdfInstances[0]
+    expect(instance.addImage).toHaveBeenCalled()
+    expect(instance.save).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/pivotAnalysisService.spec.ts
+++ b/tests/unit/pivotAnalysisService.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { PivotAnalysisService, type NormalizedEvaluationResult } from '@/services/pivotAnalysisService'
+import type { EvaluationResult, ResultTypeConfig } from '@/types/evaluation'
+
+describe('PivotAnalysisService', () => {
+  const numericConfig: ResultTypeConfig = {
+    id: 'numeric',
+    name: 'Note sur 20',
+    type: 'numeric',
+    config: {
+      minValue: 0,
+      maxValue: 20,
+      values: []
+    }
+  }
+
+  const scaleConfig: ResultTypeConfig = {
+    id: 'scale-4',
+    name: 'Échelle qualitative',
+    type: 'scale',
+    config: {
+      values: [
+        { label: 'Non acquis', value: 'NA', pivot_value: 2 },
+        { label: 'En cours', value: 'EC', pivot_value: 5 },
+        { label: 'Acquis', value: 'A', pivot_value: 8 },
+        { label: 'Maîtrisé', value: 'M', pivot_value: 10 }
+      ]
+    }
+  }
+
+  it('normalise un résultat numérique sur une échelle 0-10', () => {
+    const result: EvaluationResult = {
+      studentId: 'stu-1',
+      competencyId: 'comp-1',
+      value: '14',
+      evaluatedAt: '2025-01-01T10:00:00.000Z'
+    }
+
+    const normalized = PivotAnalysisService.normalizeEvaluationResult(result, numericConfig)
+
+    expect(normalized).toMatchObject({
+      studentId: 'stu-1',
+      competencyId: 'comp-1',
+      originalValue: '14'
+    })
+    expect(normalized?.pivotValue).toBeCloseTo(7)
+  })
+
+  it('normalise un résultat qualitatif à partir de la configuration', () => {
+    const result: EvaluationResult = {
+      studentId: 'stu-2',
+      competencyId: 'comp-2',
+      value: 'A',
+      evaluatedAt: '2025-01-01T10:00:00.000Z'
+    }
+
+    const normalized = PivotAnalysisService.normalizeEvaluationResult(result, scaleConfig)
+
+    expect(normalized?.pivotValue).toBe(8)
+  })
+
+  it('normalise plusieurs résultats en utilisant les types de résultats connus', () => {
+    const results: EvaluationResult[] = [
+      { studentId: 'stu-1', competencyId: 'comp-1', value: 'A', evaluatedAt: '2025-01-01T10:00:00.000Z' },
+      { studentId: 'stu-2', competencyId: 'comp-1', value: 'EC', evaluatedAt: '2025-01-01T10:05:00.000Z' }
+    ]
+
+    const configs = new Map<string, ResultTypeConfig>([[scaleConfig.id, scaleConfig]])
+
+    const normalized = PivotAnalysisService.normalizeEvaluationResults(results, configs)
+
+    expect(normalized).toHaveLength(2)
+    expect(normalized.map(result => result.pivotValue)).toEqual([8, 5])
+  })
+
+  it('calcule les statistiques de distribution pour les graphiques', () => {
+    const normalized: NormalizedEvaluationResult[] = [
+      { studentId: 'stu-1', competencyId: 'comp-1', originalValue: 'A', pivotValue: 8, evaluatedAt: '2025-01-01T10:00:00.000Z' },
+      { studentId: 'stu-2', competencyId: 'comp-1', originalValue: 'M', pivotValue: 10, evaluatedAt: '2025-01-01T10:05:00.000Z' },
+      { studentId: 'stu-3', competencyId: 'comp-1', originalValue: 'EC', pivotValue: 5, evaluatedAt: '2025-01-01T10:10:00.000Z' }
+    ]
+
+    const stats = PivotAnalysisService.calculateStatistics(normalized)
+
+    expect(stats).toMatchObject({
+      average: 7.67,
+      min: 5,
+      max: 10,
+      count: 3
+    })
+    expect(stats.distribution['8']).toBe(1)
+  })
+
+  it('regroupe les résultats normalisés par compétence et par élève', () => {
+    const normalized: NormalizedEvaluationResult[] = [
+      { studentId: 'stu-1', competencyId: 'comp-1', originalValue: 'A', pivotValue: 8, evaluatedAt: '2025-01-01T10:00:00.000Z' },
+      { studentId: 'stu-1', competencyId: 'comp-2', originalValue: 'M', pivotValue: 10, evaluatedAt: '2025-01-01T10:05:00.000Z' },
+      { studentId: 'stu-2', competencyId: 'comp-1', originalValue: 'EC', pivotValue: 5, evaluatedAt: '2025-01-01T10:10:00.000Z' }
+    ]
+
+    const byCompetency = PivotAnalysisService.groupByCompetency(normalized)
+    const byStudent = PivotAnalysisService.groupByStudent(normalized)
+
+    expect(Object.keys(byCompetency)).toEqual(['comp-1', 'comp-2'])
+    expect(byCompetency['comp-1']).toHaveLength(2)
+    expect(Object.keys(byStudent)).toEqual(['stu-1', 'stu-2'])
+    expect(byStudent['stu-1']).toHaveLength(2)
+  })
+
+  it('dénormalise une valeur pivot pour retrouver l\'étiquette la plus proche', () => {
+    const value = PivotAnalysisService.denormalizePivotValue(9, scaleConfig)
+    expect(value && typeof value === 'object' ? value.value : value).toBe('A')
+  })
+})

--- a/tests/unit/studentsStore.spec.ts
+++ b/tests/unit/studentsStore.spec.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Student, CompetencyFramework, Domain } from '@/types/evaluation'
+
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0))
+
+const mockStudents: Student[] = [
+  { id: 'stu-1', firstName: 'Alice', lastName: 'Martin', displayName: 'Alice M.' }
+]
+
+const mockSupabaseStudentsService = {
+  getAllStudents: vi.fn<[], Promise<Student[]>>(),
+  createStudent: vi.fn<[], Promise<Student>>(),
+  updateStudent: vi.fn<[], Promise<Student | null>>(),
+  deleteStudent: vi.fn<[], Promise<void>>()
+}
+
+const mockFramework: CompetencyFramework = {
+  id: 'framework-1',
+  name: 'Framework Test',
+  version: '1.0',
+  domains: [
+    {
+      id: 'domain-1',
+      name: 'Langue',
+      description: 'Compétences linguistiques',
+      fields: [
+        {
+          id: 'field-1',
+          name: 'Oral',
+          description: 'Expression orale',
+          competencies: []
+        }
+      ]
+    }
+  ]
+}
+
+const mockSupabaseCompetenciesService = {
+  getOrCreateDefaultFramework: vi.fn<[], Promise<{ id: string; name: string; version: string }>>(),
+  getAllDomains: vi.fn<[], Promise<Domain[]>>(),
+  updateSpecificCompetency: vi.fn<[], Promise<null>>()
+}
+
+vi.mock('@/services/supabaseStudentsService', () => ({
+  supabaseStudentsService: mockSupabaseStudentsService
+}))
+
+vi.mock('@/services/supabaseCompetenciesService', () => ({
+  supabaseCompetenciesService: mockSupabaseCompetenciesService
+}))
+
+describe('useStudentsStore', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    mockSupabaseStudentsService.getAllStudents.mockResolvedValue([...mockStudents])
+    mockSupabaseStudentsService.createStudent.mockImplementation(async (firstName: string, lastName: string) => ({
+      id: 'stu-2',
+      firstName,
+      lastName,
+      displayName: `${firstName} ${lastName.charAt(0)}.`
+    }))
+    mockSupabaseStudentsService.updateStudent.mockImplementation(async (id: string, updates: Partial<Student>) => ({
+      ...mockStudents[0],
+      ...updates,
+      displayName: `${updates.firstName ?? mockStudents[0].firstName} ${(updates.lastName ?? mockStudents[0].lastName).charAt(0)}.`
+    }))
+    mockSupabaseStudentsService.deleteStudent.mockResolvedValue()
+
+    mockSupabaseCompetenciesService.getOrCreateDefaultFramework.mockResolvedValue({
+      id: mockFramework.id,
+      name: mockFramework.name,
+      version: mockFramework.version
+    })
+    mockSupabaseCompetenciesService.getAllDomains.mockResolvedValue(mockFramework.domains as Domain[])
+    mockSupabaseCompetenciesService.updateSpecificCompetency.mockResolvedValue(null)
+  })
+
+  it('ajoute un élève en utilisant le service Supabase', async () => {
+    const { useStudentsStore } = await import('@/stores/studentsStore')
+    const store = useStudentsStore()
+
+    await flushPromises()
+
+    const newStudent = await store.addStudent({ firstName: 'Bruno', lastName: 'Dupont' })
+
+    expect(newStudent).toMatchObject({ id: 'stu-2', firstName: 'Bruno', lastName: 'Dupont' })
+    expect(store.allStudents.value).toContainEqual(newStudent)
+  })
+
+  it('met à jour un élève existant et rafraîchit le displayName', async () => {
+    const { useStudentsStore } = await import('@/stores/studentsStore')
+    const store = useStudentsStore()
+
+    await flushPromises()
+
+    const updated = await store.updateStudent('stu-1', { firstName: 'Alicia' })
+
+    expect(updated?.firstName).toBe('Alicia')
+    expect(updated?.displayName).toBe('Alicia M.')
+    expect(store.getStudentById('stu-1')?.firstName).toBe('Alicia')
+  })
+
+  it('supprime un élève et met à jour la liste', async () => {
+    const { useStudentsStore } = await import('@/stores/studentsStore')
+    const store = useStudentsStore()
+
+    await flushPromises()
+
+    const deleted = await store.deleteStudent('stu-1')
+
+    expect(deleted?.id).toBe('stu-1')
+    expect(store.getStudentById('stu-1')).toBeNull()
+  })
+})
+
+describe('useCompetencyFrameworkStore', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    mockSupabaseStudentsService.getAllStudents.mockResolvedValue([...mockStudents])
+    mockSupabaseStudentsService.createStudent.mockImplementation(async (firstName: string, lastName: string) => ({
+      id: 'stu-2',
+      firstName,
+      lastName,
+      displayName: `${firstName} ${lastName.charAt(0)}.`
+    }))
+    mockSupabaseStudentsService.updateStudent.mockImplementation(async (id: string, updates: Partial<Student>) => ({
+      ...mockStudents[0],
+      ...updates,
+      displayName: `${updates.firstName ?? mockStudents[0].firstName} ${(updates.lastName ?? mockStudents[0].lastName).charAt(0)}.`
+    }))
+    mockSupabaseStudentsService.deleteStudent.mockResolvedValue()
+
+    mockSupabaseCompetenciesService.getOrCreateDefaultFramework.mockResolvedValue({
+      id: mockFramework.id,
+      name: mockFramework.name,
+      version: mockFramework.version
+    })
+    mockSupabaseCompetenciesService.getAllDomains.mockResolvedValue(mockFramework.domains as Domain[])
+    mockSupabaseCompetenciesService.updateSpecificCompetency.mockResolvedValue(null)
+  })
+
+  it('crée, modifie et supprime une compétence', async () => {
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(1234567890)
+
+    const { useCompetencyFrameworkStore } = await import('@/stores/studentsStore')
+    const store = useCompetencyFrameworkStore()
+
+    await flushPromises()
+
+    const framework = store.framework.value
+    const fieldId = framework.domains[0].fields[0].id
+
+    const newCompetency = store.addCompetency(fieldId, {
+      name: 'Comprendre un texte',
+      description: 'Analyse de compréhension'
+    })
+
+    expect(newCompetency).toBeTruthy()
+    expect(framework.domains[0].fields[0].competencies).toContainEqual(expect.objectContaining({
+      id: 'comp-1234567890',
+      name: 'Comprendre un texte'
+    }))
+
+    const updated = store.updateCompetency(newCompetency!.id, { name: 'Compréhension écrite' })
+    expect(updated?.name).toBe('Compréhension écrite')
+
+    const deleted = store.deleteCompetency(newCompetency!.id)
+    expect(deleted?.id).toBe(newCompetency!.id)
+    expect(framework.domains[0].fields[0].competencies.find(c => c.id === newCompetency!.id)).toBeUndefined()
+
+    dateNowSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests that exercise evaluation creation, update, and deletion flows
- ensure student and competency management plus PDF exports are covered by fast unit tests
- validate pivot analysis computations and document the business features under test

## Testing
- npm run test:unit:run

------
https://chatgpt.com/codex/tasks/task_e_68d43d5a4cf08320804461765deb0d39