### PR TITLE
Align bottom nav indicator with icon

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -442,7 +442,7 @@ onUnmounted(() => {
 .nav-destinations {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 8px;
   flex: 1;
 }
@@ -458,7 +458,7 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 4px;
   padding: var(--nav-item-padding-block) var(--nav-item-padding-inline);
   min-width: 64px;


### PR DESCRIPTION
## Summary
- anchor bottom navigation destinations to start so the active indicator centers on the icon even with extra vertical space

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4484859008320b934d781f392bc82