### PR TITLE
Center bottom nav items within bar

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -445,6 +445,7 @@ onUnmounted(() => {
   justify-content: center;
   gap: 8px;
   flex: 1;
+  margin-inline: auto;
 }
 
 .nav-destination {
@@ -458,7 +459,7 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 4px;
   padding: var(--nav-item-padding-block) var(--nav-item-padding-inline);
   min-width: 64px;


### PR DESCRIPTION
## Summary
- center the horizontal navigation destinations so fixed-width items leave equal space at both ends
- keep the active indicator centered on its icon by aligning the destination group within the navigation bar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4484859008320b934d781f392bc82