### PR TITLE
Center bottom nav items within bar

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -367,7 +367,7 @@ onUnmounted(() => {
     display: block;
     font-size: 10px;
     font-weight: 400;
-    color: currentColor;
+    color: var(--md-sys-color-on-surface-variant);
     white-space: nowrap;
     text-align: center;
     margin-top: 4px;
@@ -445,6 +445,7 @@ onUnmounted(() => {
   justify-content: center;
   gap: 8px;
   flex: 1;
+  margin-inline: auto;
 }
 
 .nav-destination {
@@ -458,7 +459,7 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 4px;
   padding: var(--nav-item-padding-block) var(--nav-item-padding-inline);
   min-width: 64px;
@@ -491,17 +492,22 @@ onUnmounted(() => {
   outline-offset: 2px;
 }
 
+
 .nav-destination.active {
-  color: var(--md-sys-color-on-surface-variant);
+  background-color: transparent;
+}
+
+.nav-destination.active:hover {
+  background-color: transparent;
 }
 
 .nav-destination.active .nav-icon {
-  color: var(--md-sys-color-on-surface-variant);
+  color: var(--md-sys-color-on-primary);
 }
 
 .nav-destination.active .nav-label {
-  color: var(--md-sys-color-on-surface-variant);
   font-weight: 700;
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .nav-indicator {
@@ -551,6 +557,7 @@ onUnmounted(() => {
   text-align: center;
   z-index: 1;
   position: relative;
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .user-actions {


### PR DESCRIPTION
## Summary
- center the horizontal navigation destinations so fixed-width items leave equal space at both ends
- keep the active indicator centered on its icon by aligning the destination group within the navigation bar
- tint the active destination icon while leaving the label at its default color and clearing hover fill so the indicator is the only active background
- explicitly keep the active label color matched to the default on-surface-variant tone

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4484859008320b934d781f392bc82