### PR TITLE
chore: harden supabase auth bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ This repository provides a foundational Vue 3 PWA that is:
 npm install
 ```
 
+## Configuration de l'authentification Supabase
+
+1. Créez un fichier `.env.local` à la racine du projet :
+
+   ```bash
+   VITE_SUPABASE_URL="https://<votre-projet>.supabase.co"
+   VITE_SUPABASE_ANON_KEY="<clef-anonyme>"
+   ```
+
+2. Dans le tableau de bord Supabase, activez l'authentification par e-mail et configurez la durée de validité des liens (15 à 60 minutes recommandées).
+3. Personnalisez les e-mails d'authentification en important les modèles fournis dans `supabase/templates`. Chaque fichier correspond à un scénario (confirmation, réinitialisation, lien magique) et respecte les bonnes pratiques d'accessibilité.
+4. Vérifiez que l'URL de redirection (`Site URL`) pointe vers l'origine de votre application (ex. `https://app.mondomaine.fr`).
+
+> Les sessions sont gérées côté client via Supabase avec persistance sécurisée, rafraîchissement automatique des tokens et flux PKCE.
+
 ## Development
 
 ```bash

--- a/src/components/common/CenterAppBar.vue
+++ b/src/components/common/CenterAppBar.vue
@@ -35,7 +35,7 @@
           <span class="material-symbols-outlined">search</span>
         </button>
         <UserMenu
-          v-if="showUserMenu"
+          v-if="shouldDisplayUserMenu"
           @logout="$emit('logout')"
         />
       </slot>
@@ -44,7 +44,9 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import UserMenu from './UserMenu.vue'
+import { useAuthStore, isAuthenticated } from '@/stores/authStore'
 
 interface Props {
   title: string
@@ -62,7 +64,7 @@ interface Emits {
   (e: 'back'): void
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   isScrolled: false,
   showSearch: true,
   showUserMenu: true,
@@ -71,6 +73,11 @@ withDefaults(defineProps<Props>(), {
 })
 
 defineEmits<Emits>()
+
+const authStore = useAuthStore()
+const shouldDisplayUserMenu = computed(
+  () => props.showUserMenu && isAuthenticated.value && !authStore.isInitializing.value
+)
 </script>
 
 <style scoped>

--- a/src/components/common/SearchAppBar.vue
+++ b/src/components/common/SearchAppBar.vue
@@ -33,6 +33,7 @@
     <!-- Trailing Actions -->
     <div class="search-app-bar__trailing">
       <UserMenu
+        v-if="shouldDisplayUserMenu"
         @logout="$emit('logout')"
       />
     </div>
@@ -40,7 +41,9 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import UserMenu from './UserMenu.vue'
+import { useAuthStore, isAuthenticated } from '@/stores/authStore'
 
 interface Props {
   searchValue: string
@@ -65,6 +68,11 @@ withDefaults(defineProps<Props>(), {
 })
 
 defineEmits<Emits>()
+
+const authStore = useAuthStore()
+const shouldDisplayUserMenu = computed(
+  () => isAuthenticated.value && !authStore.isInitializing.value
+)
 </script>
 
 <style scoped>

--- a/src/components/common/UserMenu.vue
+++ b/src/components/common/UserMenu.vue
@@ -4,6 +4,7 @@
       class="icon-button user-menu-button"
       aria-label="Menu utilisateur"
       :aria-expanded="isOpen"
+      :disabled="isLoading || !signedIn"
       @click="toggleMenu"
     >
       <span class="material-symbols-outlined">more_vert</span>
@@ -16,13 +17,21 @@
             <div class="user-info">
               <span class="material-symbols-outlined user-avatar">account_circle</span>
               <div class="user-details">
-                <span class="user-name">Utilisateur</span>
-                <span class="user-role">Enseignant</span>
+                <span class="user-name">{{ displayName }}</span>
+                <span class="user-role">{{ userEmail }}</span>
+                <span
+                  v-if="!isEmailVerified"
+                  class="user-warning"
+                >
+                  E-mail à confirmer
+                </span>
               </div>
             </div>
           </div>
 
           <div class="menu-divider"></div>
+
+          <p v-if="logoutError" class="logout-error" role="alert">{{ logoutError }}</p>
 
           <nav class="menu-items">
             <router-link
@@ -55,7 +64,7 @@
             </router-link>
 
 
-            <button class="menu-item menu-item-button" @click="handleLogout">
+            <button class="menu-item menu-item-button" type="button" @click="handleLogout">
               <span class="material-symbols-outlined">logout</span>
               <span class="menu-item-text">Déconnexion</span>
             </button>
@@ -67,7 +76,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { computed, ref, onMounted, onUnmounted } from 'vue'
+import { useAuthStore, isAuthenticated } from '@/stores/authStore'
 
 interface Emits {
   (e: 'logout'): void
@@ -77,6 +87,14 @@ const emit = defineEmits<Emits>()
 
 const isOpen = ref(false)
 const userMenuRef = ref<HTMLElement>()
+const authStore = useAuthStore()
+const logoutError = ref<string | null>(null)
+
+const displayName = computed(() => authStore.displayName.value)
+const userEmail = computed(() => authStore.userEmail.value)
+const isEmailVerified = computed(() => authStore.isEmailVerified.value)
+const isLoading = computed(() => authStore.isInitializing.value)
+const signedIn = computed(() => isAuthenticated.value)
 
 function toggleMenu() {
   isOpen.value = !isOpen.value
@@ -92,7 +110,14 @@ function handleClickOutside(event: Event) {
   }
 }
 
-function handleLogout() {
+async function handleLogout() {
+  logoutError.value = null
+  const { error } = await authStore.signOut()
+  if (error) {
+    logoutError.value = "La déconnexion a échoué. Merci de réessayer."
+    return
+  }
+
   emit('logout')
   closeMenu()
 }
@@ -217,6 +242,13 @@ onUnmounted(() => {
   color: var(--md-sys-color-on-surface-variant);
 }
 
+.user-warning {
+  font-family: var(--md-sys-typescale-body-small-font);
+  font-size: var(--md-sys-typescale-body-small-size);
+  color: var(--md-sys-color-error);
+  font-weight: 600;
+}
+
 .menu-divider {
   height: 1px;
   background: var(--md-sys-color-outline-variant);
@@ -264,6 +296,20 @@ onUnmounted(() => {
 
 .menu-item-button {
   text-align: left;
+}
+
+.logout-error {
+  margin: 0 16px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--md-sys-color-error) 12%, transparent);
+  color: var(--md-sys-color-error);
+  font-size: 0.875rem;
+}
+
+.user-menu-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 /* Transitions */

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -5,6 +5,8 @@ import type { Database } from '../types/database.types'
 const isTestEnvironment = typeof process !== 'undefined' && process.env.NODE_ENV === 'test'
 const isVitest = typeof process !== 'undefined' && process.env.VITEST === 'true'
 
+let hasWarnedAboutCredentials = false
+
 // Mock Supabase pour les tests (directement dans le fichier)
 const createMockSupabase = () => {
   const createChainableMock = () => {
@@ -44,6 +46,25 @@ const createMockSupabase = () => {
     upsert: (_data: any, _options?: any) => createChainableMock()
   })
 
+  const authMock = {
+    getSession: async () => ({ data: { session: null }, error: null }),
+    signInWithPassword: async () => ({ data: { session: null, user: null }, error: null }),
+    signUp: async () => ({ data: { session: null, user: null }, error: null }),
+    signOut: async () => ({ error: null }),
+    resetPasswordForEmail: async () => ({ error: null }),
+    updateUser: async () => ({ data: { user: null }, error: null }),
+    refreshSession: async () => ({ data: { session: null, user: null }, error: null }),
+    resend: async () => ({ error: null }),
+    exchangeCodeForSession: async () => ({ data: { session: null }, error: null }),
+    onAuthStateChange: () => ({
+      data: {
+        subscription: {
+          unsubscribe: () => undefined
+        }
+      }
+    })
+  }
+
   return {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     from: (_table: any) => createTableMock(),
@@ -52,32 +73,44 @@ const createMockSupabase = () => {
       on: (..._args: any[]) => ({
         subscribe: () => ({})
       })
-    })
+    }),
+    auth: authMock
   }
 }
 
 // Créer le client approprié selon l'environnement
 function createSupabaseClient(): SupabaseClient<Database> {
-  if (isTestEnvironment || isVitest) {
-    return createMockSupabase() as unknown as SupabaseClient<Database>
-  } else {
-    // En mode production/développement, utiliser le vrai client Supabase
-    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || ''
-    const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || ''
+  const shouldMock = isTestEnvironment || isVitest
 
-    if (!supabaseUrl || !supabaseAnonKey) {
-      console.warn('Supabase credentials not configured. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your .env file')
-      // Créer un client avec des valeurs par défaut pour éviter les erreurs
-      return createClient<Database>('https://localhost', 'dummy-key')
-    } else {
-      return createClient<Database>(supabaseUrl, supabaseAnonKey, {
-        auth: {
-          persistSession: true,
-          autoRefreshToken: true,
-        }
-      })
-    }
+  if (shouldMock) {
+    return createMockSupabase() as unknown as SupabaseClient<Database>
   }
+
+  // En mode production/développement, utiliser le vrai client Supabase si les credentials sont fournis
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || ''
+  const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || ''
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    if (!hasWarnedAboutCredentials) {
+      console.warn(
+        '[Supabase] Credentials not configured. Falling back to an in-memory mock client.\n' +
+          'Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your .env.local to enable remote authentication.'
+      )
+      hasWarnedAboutCredentials = true
+    }
+
+    return createMockSupabase() as unknown as SupabaseClient<Database>
+  }
+
+  return createClient<Database>(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+      flowType: 'pkce',
+      storageKey: 'evaluations.auth.token'
+    }
+  })
 }
 
 export const supabase = createSupabaseClient()

--- a/src/router/route-names.ts
+++ b/src/router/route-names.ts
@@ -1,0 +1,17 @@
+export const ROUTE_NAMES = {
+  HOME: 'home',
+  WELCOME: 'welcome',
+  AUTH: 'auth',
+  AUTH_CALLBACK: 'auth-callback',
+  EVALUATIONS: 'evaluations',
+  EVALUATION_DETAIL: 'evaluation-detail',
+  EVALUATION_EDIT: 'evaluation-edit',
+  STUDENTS: 'students',
+  COMPETENCIES: 'competencies',
+  TYPES: 'types',
+  ANALYSIS: 'analysis',
+  SETTINGS: 'settings'
+} as const
+
+type RouteNameMap = typeof ROUTE_NAMES
+export type AppRouteName = RouteNameMap[keyof RouteNameMap]

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,0 +1,266 @@
+import { ref, readonly, computed } from 'vue'
+import type { Session, User, AuthError } from '@supabase/supabase-js'
+import { supabase } from '@/lib/supabase'
+
+const currentUser = ref<User | null>(null)
+const currentSession = ref<Session | null>(null)
+const isInitializing = ref(true)
+const lastError = ref<AuthError | null>(null)
+const hasInteracted = ref(false)
+
+let isInitialized = false
+let authListener: ReturnType<typeof supabase.auth.onAuthStateChange> | null = null
+let initializationPromise: Promise<void> | null = null
+
+const applySession = (session: Session | null) => {
+  currentSession.value = session
+  currentUser.value = session?.user ?? null
+}
+
+const resetError = () => {
+  lastError.value = null
+}
+
+const stopAuthListener = () => {
+  if (authListener) {
+    authListener.data.subscription.unsubscribe()
+    authListener = null
+  }
+}
+
+const startAuthListener = () => {
+  if (authListener) {
+    return
+  }
+
+  authListener = supabase.auth.onAuthStateChange((_event, session) => {
+    applySession(session)
+    if (!hasInteracted.value) {
+      hasInteracted.value = true
+    }
+  })
+}
+
+const loadInitialSession = async () => {
+  if (isInitialized) {
+    return
+  }
+
+  if (!initializationPromise) {
+    initializationPromise = (async () => {
+      isInitializing.value = true
+      try {
+        const { data, error } = await supabase.auth.getSession()
+        if (error) {
+          lastError.value = error
+          applySession(null)
+        } else {
+          applySession(data.session)
+        }
+        startAuthListener()
+      } finally {
+        isInitializing.value = false
+        isInitialized = true
+        initializationPromise = null
+      }
+    })()
+  }
+
+  await initializationPromise
+}
+
+const ensureInitialized = async () => {
+  await loadInitialSession()
+}
+
+const getRedirectTo = () => {
+  if (typeof window === 'undefined') {
+    return undefined
+  }
+
+  const url = new URL(window.location.href)
+  const redirectParam = url.searchParams.get('redirect') || url.searchParams.get('redirectTo')
+
+  const isSafeRedirect = (value: string | null) => Boolean(value && value.startsWith('/'))
+
+  const callbackUrl = new URL('/auth/callback', window.location.origin)
+
+  if (isSafeRedirect(redirectParam)) {
+    callbackUrl.searchParams.set('redirect', redirectParam as string)
+  }
+
+  return callbackUrl.toString()
+}
+
+const signInWithPassword = async (email: string, password: string) => {
+  hasInteracted.value = true
+  resetError()
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password })
+  if (error) {
+    lastError.value = error
+    return { data: null, error }
+  }
+
+  applySession(data.session)
+  return { data, error: null }
+}
+
+interface SignUpPayload {
+  email: string
+  password: string
+  fullName?: string
+}
+
+const signUpWithEmail = async ({ email, password, fullName }: SignUpPayload) => {
+  hasInteracted.value = true
+  resetError()
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      emailRedirectTo: getRedirectTo(),
+      data: {
+        full_name: fullName?.trim()
+      }
+    }
+  })
+
+  if (error) {
+    lastError.value = error
+    return { data: null, error }
+  }
+
+  if (data.session) {
+    applySession(data.session)
+  } else if (data.user) {
+    currentUser.value = data.user
+  }
+  return { data, error: null }
+}
+
+const signOut = async () => {
+  resetError()
+  const { error } = await supabase.auth.signOut({ scope: 'global' })
+  if (error) {
+    lastError.value = error
+    return { error }
+  }
+
+  applySession(null)
+  return { error: null }
+}
+
+const sendPasswordReset = async (email: string) => {
+  resetError()
+  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo: getRedirectTo()
+  })
+
+  if (error) {
+    lastError.value = error
+  }
+
+  return { error }
+}
+
+const updateProfile = async (payload: { fullName?: string; password?: string }) => {
+  resetError()
+  const { fullName, password } = payload
+
+  if (typeof fullName === 'undefined' && !password) {
+    return { data: null, error: null }
+  }
+
+  const updateData: { data?: Record<string, unknown>; password?: string } = {}
+
+  if (fullName !== undefined) {
+    updateData.data = { full_name: fullName }
+  }
+
+  if (password) {
+    updateData.password = password
+  }
+
+  const { data, error } = await supabase.auth.updateUser(updateData)
+  if (error) {
+    lastError.value = error
+    return { data: null, error }
+  }
+
+  currentUser.value = data.user
+  return { data, error: null }
+}
+
+const refreshSession = async () => {
+  resetError()
+  const { data, error } = await supabase.auth.refreshSession()
+  if (error) {
+    lastError.value = error
+  } else {
+    applySession(data.session)
+  }
+  return { data, error }
+}
+
+const resendEmailVerification = async () => {
+  if (!currentUser.value?.email) {
+    return { error: new Error('Utilisateur inconnu') }
+  }
+  const { error } = await supabase.auth.resend({
+    type: 'signup',
+    email: currentUser.value.email
+  })
+
+  if (error) {
+    lastError.value = error
+  }
+
+  return { error }
+}
+
+// Démarre automatiquement l'initialisation au chargement du module
+void loadInitialSession()
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeunload', stopAuthListener, { once: true })
+}
+
+const userEmail = computed(() => currentUser.value?.email ?? '')
+const userMetadata = computed(() => currentUser.value?.user_metadata ?? {})
+const displayName = computed(() => {
+  const metadataName = (userMetadata.value as { full_name?: string }).full_name
+  if (metadataName && metadataName.trim().length > 0) {
+    return metadataName.trim()
+  }
+  if (currentUser.value?.email) {
+    return currentUser.value.email.split('@')[0]
+  }
+  return 'Utilisateur'
+})
+
+const emailVerifiedAt = computed(() => currentUser.value?.email_confirmed_at)
+const isEmailVerified = computed(() => Boolean(emailVerifiedAt.value))
+
+export const useAuthStore = () => {
+  return {
+    user: readonly(currentUser),
+    session: readonly(currentSession),
+    isInitializing: readonly(isInitializing),
+    lastError: readonly(lastError),
+    hasInteracted: readonly(hasInteracted),
+    displayName,
+    userEmail,
+    isEmailVerified,
+    ensureInitialized,
+    signInWithPassword,
+    signUpWithEmail,
+    signOut,
+    sendPasswordReset,
+    updateProfile,
+    refreshSession,
+    resendEmailVerification,
+    resetError
+  }
+}
+
+export const isAuthenticated = computed(() => Boolean(currentUser.value))

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -31,16 +31,19 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useRouter } from 'vue-router'
 
 // Components
 import CenterAppBar from '@/components/common/CenterAppBar.vue'
 import AnalysisTabs from '@/components/analysis/AnalysisTabs.vue'
 import DashboardView from '@/components/analysis/DashboardView.vue'
 import StudentAnalysisView from '@/components/analysis/StudentAnalysisView.vue'
+import { ROUTE_NAMES } from '@/router/route-names'
 
 // State
 const activeView = ref('dashboard')
 const isScrolled = ref(false)
+const router = useRouter()
 
 
 // Tab configuration
@@ -198,9 +201,8 @@ const handleUserMenuClick = () => {
 }
 
 
-const handleLogout = () => {
-  console.log('Logout requested')
-  window.alert('Déconnexion - Fonctionnalité à venir')
+const handleLogout = async () => {
+  await router.replace({ name: ROUTE_NAMES.AUTH })
 }
 </script>
 

--- a/src/views/AuthCallbackView.vue
+++ b/src/views/AuthCallbackView.vue
@@ -1,0 +1,156 @@
+<template>
+  <div class="auth-callback">
+    <div class="auth-callback-card" role="status" :aria-live="status === 'error' ? 'assertive' : 'polite'">
+      <span class="material-symbols-outlined callback-icon" :class="status">
+        {{ status === 'error' ? 'error' : status === 'success' ? 'check_circle' : 'sync' }}
+      </span>
+      <h1 class="callback-title">
+        {{ status === 'error' ? 'Échec de la connexion' : 'Connexion en cours' }}
+      </h1>
+      <p class="callback-message">{{ statusMessage }}</p>
+      <button
+        v-if="status === 'error'"
+        type="button"
+        class="callback-button"
+        @click="goBackToAuth"
+      >
+        Retourner à l'écran de connexion
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { supabase } from '@/lib/supabase'
+import { useAuthStore } from '@/stores/authStore'
+import { ROUTE_NAMES } from '@/router/route-names'
+
+const route = useRoute()
+const router = useRouter()
+const authStore = useAuthStore()
+
+const status = ref<'loading' | 'success' | 'error'>('loading')
+const statusMessage = ref('Vérification de votre session sécurisée...')
+
+const sanitizeRedirectPath = (value: unknown) => {
+  const candidate = Array.isArray(value) ? value[0] : value
+  if (typeof candidate === 'string' && candidate.startsWith('/')) {
+    return candidate
+  }
+  return '/welcome'
+}
+
+const redirectTarget = sanitizeRedirectPath(route.query.redirect)
+
+const exchangeTokenFromUrl = async () => {
+  const hasCodeParam = typeof route.query.code === 'string'
+  const hasAccessTokenHash = typeof window !== 'undefined' && window.location.hash.includes('access_token')
+
+  if (hasCodeParam || hasAccessTokenHash) {
+    const { error } = await supabase.auth.exchangeCodeForSession(window.location.href)
+    if (error) {
+      throw error
+    }
+  }
+}
+
+onMounted(async () => {
+  try {
+    if (typeof route.query.error_description === 'string') {
+      throw new Error(route.query.error_description)
+    }
+
+    await exchangeTokenFromUrl()
+    await authStore.ensureInitialized()
+
+    status.value = 'success'
+    statusMessage.value = 'Authentification réussie. Vous allez être redirigé(e)...'
+
+    setTimeout(async () => {
+      await router.replace(redirectTarget)
+    }, 800)
+  } catch (error) {
+    console.error('Erreur lors de la récupération de la session Supabase', error)
+    status.value = 'error'
+    statusMessage.value =
+      "Nous n'avons pas pu finaliser la connexion. Le lien a peut-être expiré ou a déjà été utilisé."
+  }
+})
+
+function goBackToAuth() {
+  void router.replace({ name: ROUTE_NAMES.AUTH, query: { redirect: redirectTarget } })
+}
+</script>
+
+<style scoped>
+.auth-callback {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--md-sys-color-surface);
+  padding: 24px;
+}
+
+.auth-callback-card {
+  background: var(--md-sys-color-surface-container);
+  border-radius: 24px;
+  padding: clamp(24px, 4vw, 40px);
+  max-width: 420px;
+  width: 100%;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--md-sys-elevation-level2);
+}
+
+.callback-icon {
+  font-size: 48px;
+  color: var(--md-sys-color-primary);
+  animation: spin 1.4s linear infinite;
+}
+
+.callback-icon.success {
+  animation: none;
+  color: var(--md-sys-color-secondary);
+}
+
+.callback-icon.error {
+  animation: none;
+  color: var(--md-sys-color-error);
+}
+
+.callback-title {
+  margin: 0;
+  color: var(--md-sys-color-on-surface);
+  font-size: 1.5rem;
+}
+
+.callback-message {
+  margin: 0;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.callback-button {
+  align-self: center;
+  padding: 12px 18px;
+  border-radius: 999px;
+  border: none;
+  background: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/src/views/AuthView.vue
+++ b/src/views/AuthView.vue
@@ -1,0 +1,731 @@
+<template>
+  <div class="auth-layout">
+    <section class="auth-panel" role="main">
+      <header class="auth-header">
+        <div class="auth-brand">
+          <span class="material-symbols-outlined" aria-hidden="true">verified_user</span>
+          <div class="auth-brand-text">
+            <h1 class="auth-title">Connexion sécurisée</h1>
+            <p class="auth-subtitle">Gérez vos évaluations en toute confiance</p>
+          </div>
+        </div>
+      </header>
+
+      <div class="auth-card" :aria-busy="isSubmitting || isInitializing">
+        <div class="auth-tabs" role="tablist" aria-label="Choix du formulaire d'authentification">
+          <button
+            id="signin-tab"
+            class="auth-tab"
+            role="tab"
+            :tabindex="activeTab === 'signin' ? 0 : -1"
+            :aria-selected="activeTab === 'signin'"
+            @click="switchTab('signin')"
+          >
+            Connexion
+          </button>
+          <button
+            id="signup-tab"
+            class="auth-tab"
+            role="tab"
+            :tabindex="activeTab === 'signup' ? 0 : -1"
+            :aria-selected="activeTab === 'signup'"
+            @click="switchTab('signup')"
+          >
+            Inscription
+          </button>
+        </div>
+
+        <Transition name="fade" mode="out-in">
+          <form
+            v-if="activeTab === 'signin'"
+            key="signin"
+            class="auth-form"
+            autocomplete="on"
+            aria-labelledby="signin-tab"
+            @submit.prevent="handleSignIn"
+          >
+            <p v-if="message && !isSubmitting" class="auth-message" role="status">{{ message }}</p>
+            <p v-if="errorMessage && !isSubmitting" class="auth-error" role="alert">{{ errorMessage }}</p>
+
+            <label class="auth-field">
+              <span class="auth-label">Adresse e-mail</span>
+              <input
+                v-model.trim="signInForm.email"
+                type="email"
+                name="email"
+                inputmode="email"
+                autocomplete="email"
+                required
+                :disabled="isFormDisabled"
+              />
+            </label>
+
+            <label class="auth-field">
+              <span class="auth-label">Mot de passe</span>
+              <input
+                v-model="signInForm.password"
+                :type="showSignInPassword ? 'text' : 'password'"
+                name="current-password"
+                autocomplete="current-password"
+                minlength="8"
+                required
+                :disabled="isFormDisabled"
+              />
+              <button
+                type="button"
+                class="password-toggle"
+                :aria-label="showSignInPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'"
+                @click="showSignInPassword = !showSignInPassword"
+              >
+                <span class="material-symbols-outlined" aria-hidden="true">
+                  {{ showSignInPassword ? 'visibility_off' : 'visibility' }}
+                </span>
+              </button>
+            </label>
+
+            <div class="auth-links">
+              <button type="button" class="link-button" @click="switchTab('forgot')">
+                Mot de passe oublié ?
+              </button>
+            </div>
+
+            <button
+              class="auth-submit"
+              type="submit"
+              :disabled="!canSubmitSignIn || isFormDisabled"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true">login</span>
+              <span>{{ isSubmitting ? 'Connexion en cours...' : 'Se connecter' }}</span>
+            </button>
+          </form>
+
+          <form
+            v-else-if="activeTab === 'signup'"
+            key="signup"
+            class="auth-form"
+            autocomplete="on"
+            aria-labelledby="signup-tab"
+            @submit.prevent="handleSignUp"
+          >
+            <p v-if="message && !isSubmitting" class="auth-message" role="status">{{ message }}</p>
+            <p v-if="errorMessage && !isSubmitting" class="auth-error" role="alert">{{ errorMessage }}</p>
+
+            <label class="auth-field">
+              <span class="auth-label">Nom complet</span>
+              <input
+                v-model.trim="signUpForm.fullName"
+                type="text"
+                name="name"
+                autocomplete="name"
+                placeholder="Ex : Jeanne Dupont"
+                :disabled="isFormDisabled"
+              />
+            </label>
+
+            <label class="auth-field">
+              <span class="auth-label">Adresse e-mail</span>
+              <input
+                v-model.trim="signUpForm.email"
+                type="email"
+                name="new-email"
+                inputmode="email"
+                autocomplete="email"
+                required
+                :disabled="isFormDisabled"
+              />
+            </label>
+
+            <label class="auth-field">
+              <span class="auth-label">Mot de passe</span>
+              <input
+                v-model="signUpForm.password"
+                :type="showSignUpPassword ? 'text' : 'password'"
+                name="new-password"
+                autocomplete="new-password"
+                minlength="12"
+                required
+                :disabled="isFormDisabled"
+              />
+              <button
+                type="button"
+                class="password-toggle"
+                :aria-label="showSignUpPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'"
+                @click="showSignUpPassword = !showSignUpPassword"
+              >
+                <span class="material-symbols-outlined" aria-hidden="true">
+                  {{ showSignUpPassword ? 'visibility_off' : 'visibility' }}
+                </span>
+              </button>
+              <small class="field-hint">12 caractères minimum avec lettres et chiffres.</small>
+            </label>
+
+            <label class="auth-field">
+              <span class="auth-label">Confirmation du mot de passe</span>
+              <input
+                v-model="signUpForm.confirmPassword"
+                :type="showSignUpPassword ? 'text' : 'password'"
+                name="confirm-password"
+                autocomplete="new-password"
+                required
+                :disabled="isFormDisabled"
+              />
+            </label>
+
+            <button
+              class="auth-submit"
+              type="submit"
+              :disabled="!canSubmitSignUp || isFormDisabled"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true">person_add</span>
+              <span>{{ isSubmitting ? 'Création du compte...' : 'Créer mon compte' }}</span>
+            </button>
+          </form>
+
+          <form
+            v-else
+            key="forgot"
+            class="auth-form"
+            autocomplete="on"
+            aria-labelledby="forgot-password-title"
+            @submit.prevent="handlePasswordReset"
+          >
+            <h2 id="forgot-password-title" class="auth-secondary-title">Réinitialiser le mot de passe</h2>
+            <p class="auth-description">
+              Indiquez votre adresse e-mail pour recevoir un lien de réinitialisation sécurisé.
+            </p>
+
+            <p v-if="message && !isSubmitting" class="auth-message" role="status">{{ message }}</p>
+            <p v-if="errorMessage && !isSubmitting" class="auth-error" role="alert">{{ errorMessage }}</p>
+
+            <label class="auth-field">
+              <span class="auth-label">Adresse e-mail</span>
+              <input
+                v-model.trim="resetEmail"
+                type="email"
+                name="recovery-email"
+                autocomplete="email"
+                required
+                :disabled="isFormDisabled"
+              />
+            </label>
+
+            <div class="auth-links">
+              <button type="button" class="link-button" @click="switchTab('signin')">
+                Retour à la connexion
+              </button>
+            </div>
+
+            <button
+              class="auth-submit"
+              type="submit"
+              :disabled="!resetEmail || isFormDisabled"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true">mail</span>
+              <span>{{ isSubmitting ? 'Envoi en cours...' : 'Envoyer le lien' }}</span>
+            </button>
+          </form>
+        </Transition>
+      </div>
+    </section>
+
+    <aside class="auth-aside" aria-hidden="true">
+      <div class="auth-illustration">
+        <h2>Une plateforme conçue pour les enseignants</h2>
+        <ul>
+          <li>Suivi précis des compétences et des progrès</li>
+          <li>Partage sécurisé des évaluations</li>
+          <li>Accès protégé et conforme RGPD</li>
+        </ul>
+      </div>
+    </aside>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import type { LocationQueryRaw } from 'vue-router'
+import type { AuthError } from '@supabase/supabase-js'
+import { useAuthStore } from '@/stores/authStore'
+
+const route = useRoute()
+const router = useRouter()
+const authStore = useAuthStore()
+
+const activeTab = ref<'signin' | 'signup' | 'forgot'>(getInitialTab())
+const isSubmitting = ref(false)
+const message = ref<string | null>(null)
+const errorMessage = ref<string | null>(null)
+const showSignInPassword = ref(false)
+const showSignUpPassword = ref(false)
+
+const signInForm = reactive({
+  email: getInitialEmail(),
+  password: ''
+})
+
+const signUpForm = reactive({
+  fullName: '',
+  email: getInitialEmail(),
+  password: '',
+  confirmPassword: ''
+})
+
+const resetEmail = ref(getInitialEmail())
+
+const isInitializing = computed(() => authStore.isInitializing.value)
+const isFormDisabled = computed(() => isSubmitting.value || isInitializing.value)
+
+watch(
+  () => route.query.mode,
+  (mode) => {
+    if (mode === 'signup') {
+      activeTab.value = 'signup'
+    } else if (mode === 'forgot') {
+      activeTab.value = 'forgot'
+    } else {
+      activeTab.value = 'signin'
+    }
+  }
+)
+
+watch(
+  () => route.query.email,
+  (email) => {
+    if (typeof email === 'string') {
+      signInForm.email = email
+      signUpForm.email = email
+      resetEmail.value = email
+    }
+  }
+)
+
+watch(
+  () => authStore.lastError.value,
+  (error) => {
+    if (error) {
+      errorMessage.value = translateError(error)
+    }
+  }
+)
+
+function getInitialTab() {
+  const mode = route.query.mode
+  if (mode === 'signup') {
+    return 'signup' as const
+  }
+  if (mode === 'forgot') {
+    return 'forgot' as const
+  }
+  return 'signin' as const
+}
+
+function getInitialEmail() {
+  const email = route.query.email
+  return typeof email === 'string' ? email : ''
+}
+
+const sanitizeRedirectPath = (value: unknown) => {
+  const candidate = Array.isArray(value) ? value[0] : value
+  if (typeof candidate === 'string' && candidate.startsWith('/')) {
+    return candidate
+  }
+  return '/welcome'
+}
+
+const redirectPath = computed(() => sanitizeRedirectPath(route.query.redirect))
+
+const canSubmitSignIn = computed(() => {
+  return Boolean(signInForm.email && signInForm.password.length >= 8)
+})
+
+const passwordHasLetters = computed(() => /[A-Za-zÀ-ÿ]/.test(signUpForm.password))
+const passwordHasNumbers = computed(() => /\d/.test(signUpForm.password))
+
+const canSubmitSignUp = computed(() => {
+  return (
+    Boolean(signUpForm.email) &&
+    signUpForm.password.length >= 12 &&
+    passwordHasLetters.value &&
+    passwordHasNumbers.value &&
+    signUpForm.password === signUpForm.confirmPassword
+  )
+})
+
+function translateError(error: AuthError | Error) {
+  const message = error.message?.toLowerCase?.() ?? ''
+  if (message.includes('invalid login')) {
+    return 'Adresse e-mail ou mot de passe invalide.'
+  }
+  if (message.includes('email rate limit')) {
+    return 'Vous avez demandé trop d\'e-mails sur une courte période. Veuillez patienter quelques minutes.'
+  }
+  if (message.includes('password')) {
+    return 'Le mot de passe ne respecte pas les critères de sécurité requis.'
+  }
+  if (message.includes('already registered')) {
+    return 'Un compte existe déjà avec cette adresse e-mail. Vous pouvez vous connecter directement.'
+  }
+  return "Une erreur est survenue. Merci de réessayer ou de contacter le support si le problème persiste."
+}
+
+function resetFeedback() {
+  message.value = null
+  errorMessage.value = null
+  authStore.resetError()
+}
+
+async function handleSignIn() {
+  resetFeedback()
+  if (!canSubmitSignIn.value) {
+    return
+  }
+
+  isSubmitting.value = true
+  const { error } = await authStore.signInWithPassword(signInForm.email, signInForm.password)
+  isSubmitting.value = false
+
+  if (error) {
+    errorMessage.value = translateError(error)
+    return
+  }
+
+  message.value = 'Connexion réussie. Redirection en cours...'
+  signInForm.password = ''
+  await router.replace(redirectPath.value)
+}
+
+async function handleSignUp() {
+  resetFeedback()
+  if (!canSubmitSignUp.value) {
+    errorMessage.value = 'Veuillez vérifier les informations saisies.'
+    return
+  }
+
+  isSubmitting.value = true
+  const { error } = await authStore.signUpWithEmail({
+    email: signUpForm.email,
+    password: signUpForm.password,
+    fullName: signUpForm.fullName
+  })
+  isSubmitting.value = false
+
+  if (error) {
+    errorMessage.value = translateError(error)
+    return
+  }
+
+  message.value =
+    'Votre compte a été créé. Un e-mail de confirmation vient de vous être envoyé pour sécuriser votre inscription.'
+  signInForm.email = signUpForm.email
+  signUpForm.fullName = signUpForm.fullName.trim()
+  signUpForm.password = ''
+  signUpForm.confirmPassword = ''
+  activeTab.value = 'signin'
+}
+
+async function handlePasswordReset() {
+  resetFeedback()
+  if (!resetEmail.value) {
+    errorMessage.value = 'Merci d\'indiquer votre adresse e-mail.'
+    return
+  }
+
+  isSubmitting.value = true
+  const { error } = await authStore.sendPasswordReset(resetEmail.value)
+  isSubmitting.value = false
+
+  if (error) {
+    errorMessage.value = translateError(error)
+    return
+  }
+
+  message.value =
+    'Si cette adresse correspond à un compte existant, un e-mail de réinitialisation vient d\'être envoyé.'
+}
+
+function switchTab(tab: 'signin' | 'signup' | 'forgot') {
+  resetFeedback()
+  activeTab.value = tab
+  const nextQuery: LocationQueryRaw = {}
+
+  Object.entries(route.query).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      nextQuery[key] = value.filter((entry): entry is string => typeof entry === 'string')
+    } else if (typeof value === 'string') {
+      nextQuery[key] = value
+    } else if (value === null) {
+      nextQuery[key] = null
+    }
+  })
+  if (tab === 'signin') {
+    delete nextQuery.mode
+  } else {
+    nextQuery.mode = tab
+  }
+
+  void router.replace({ query: nextQuery })
+}
+</script>
+
+<style scoped>
+.auth-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 520px) minmax(0, 1fr);
+  min-height: 100vh;
+  background: var(--md-sys-color-surface);
+}
+
+.auth-panel {
+  display: flex;
+  flex-direction: column;
+  padding: clamp(24px, 4vw, 64px);
+  gap: 32px;
+}
+
+.auth-header {
+  display: flex;
+  justify-content: center;
+}
+
+.auth-brand {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.auth-brand .material-symbols-outlined {
+  font-size: 40px;
+  color: var(--md-sys-color-primary);
+}
+
+.auth-brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.auth-title {
+  font-family: var(--md-sys-typescale-headline-small-font);
+  font-size: var(--md-sys-typescale-headline-small-size);
+  margin: 0;
+  color: var(--md-sys-color-on-surface);
+}
+
+.auth-subtitle {
+  margin: 0;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.auth-card {
+  background: var(--md-sys-color-surface-container);
+  border-radius: 24px;
+  box-shadow: var(--md-sys-elevation-level2);
+  padding: clamp(24px, 4vw, 40px);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.auth-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  border-radius: 16px;
+  background: var(--md-sys-color-surface-container-high);
+  padding: 4px;
+}
+
+.auth-tab {
+  border: none;
+  border-radius: 12px;
+  padding: 12px 16px;
+  background: transparent;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface-variant);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.auth-tab[aria-selected='true'] {
+  background: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary);
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.auth-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: relative;
+}
+
+.auth-label {
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface);
+}
+
+.auth-field input {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-field input:focus {
+  outline: none;
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--md-sys-color-primary) 24%, transparent);
+}
+
+.password-toggle {
+  position: absolute;
+  right: 12px;
+  top: 45px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--md-sys-color-on-surface-variant);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.field-hint {
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.875rem;
+}
+
+.auth-links {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: var(--md-sys-color-primary);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.auth-submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-radius: 999px;
+  border: none;
+  background: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary);
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.auth-submit:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: var(--md-sys-elevation-level2);
+}
+
+.auth-message {
+  background: color-mix(in srgb, var(--md-sys-color-primary) 12%, transparent);
+  color: var(--md-sys-color-primary);
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.auth-error {
+  background: color-mix(in srgb, var(--md-sys-color-error) 12%, transparent);
+  color: var(--md-sys-color-error);
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.auth-secondary-title {
+  margin: 0;
+  font-size: 1.3rem;
+  color: var(--md-sys-color-on-surface);
+}
+
+.auth-description {
+  margin: 0;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.auth-aside {
+  background: linear-gradient(160deg, color-mix(in srgb, var(--md-sys-color-primary) 20%, transparent) 0%, transparent 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(24px, 5vw, 64px);
+}
+
+.auth-illustration {
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  color: var(--md-sys-color-on-surface);
+}
+
+.auth-illustration h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+}
+
+.auth-illustration ul {
+  margin: 0;
+  padding: 0 0 0 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.15s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 1024px) {
+  .auth-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-aside {
+    display: none;
+  }
+}
+
+@media (max-width: 600px) {
+  .auth-panel {
+    padding: 24px 16px;
+  }
+
+  .auth-card {
+    padding: 20px;
+  }
+}
+</style>

--- a/src/views/CompetenciesView.vue
+++ b/src/views/CompetenciesView.vue
@@ -57,6 +57,7 @@ import type { Domain, ResultTypeConfig } from '@/types/evaluation'
 import { useCompetencyFrameworkStore } from '@/stores/studentsStore'
 import { SupabaseCompetenciesService } from '@/services/supabaseCompetenciesService'
 import { SupabaseResultTypesService } from '@/services/supabaseResultTypesService'
+import { ROUTE_NAMES } from '@/router/route-names'
 
 // Store
 const competencyStore = useCompetencyFrameworkStore()
@@ -346,9 +347,8 @@ const handleUserMenuClick = () => {
 }
 
 
-const handleLogout = () => {
-  console.log('Logout requested')
-  window.alert('Déconnexion - Fonctionnalité à venir')
+const handleLogout = async () => {
+  await router.replace({ name: ROUTE_NAMES.AUTH })
 }
 </script>
 

--- a/src/views/EvaluationEditView.vue
+++ b/src/views/EvaluationEditView.vue
@@ -118,6 +118,7 @@ import { useRoute, useRouter } from 'vue-router'
 import CenterAppBar from '@/components/common/CenterAppBar.vue'
 import { useEvaluationStore } from '@/stores/evaluationStore'
 import type { Evaluation } from '@/types/evaluation'
+import { ROUTE_NAMES } from '@/router/route-names'
 
 const route = useRoute()
 const router = useRouter()
@@ -174,9 +175,8 @@ const handleScroll = () => {
   isScrolled.value = window.scrollY > 0
 }
 
-const handleLogout = () => {
-  console.log('Logout requested')
-  window.alert('Déconnexion - Fonctionnalité à venir')
+const handleLogout = async () => {
+  await router.replace({ name: ROUTE_NAMES.AUTH })
 }
 
 const goBack = () => {

--- a/src/views/EvaluationListView.vue
+++ b/src/views/EvaluationListView.vue
@@ -96,6 +96,8 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 
+import { ROUTE_NAMES } from '@/router/route-names'
+
 // Components
 import CenterAppBar from '@/components/common/CenterAppBar.vue'
 import MenuFAB from '@/components/common/MenuFAB.vue'
@@ -165,9 +167,8 @@ const handleUserMenuClick = () => {
 }
 
 
-const handleLogout = () => {
-  console.log('Logout requested')
-  window.alert('Déconnexion - Fonctionnalité à venir')
+const handleLogout = async () => {
+  await router.replace({ name: ROUTE_NAMES.AUTH })
 }
 
 const openAddModal = () => {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -63,6 +63,7 @@
 <script setup lang="ts">
 import { ref, defineAsyncComponent, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { ROUTE_NAMES } from '@/router/route-names'
 
 // Define props for the evaluation ID
 interface Props {
@@ -149,9 +150,8 @@ onUnmounted(() => {
 
 // Event handlers
 
-const handleLogout = () => {
-  console.log('Logout requested')
-  window.alert('Déconnexion - Fonctionnalité à venir')
+const handleLogout = async () => {
+  await router.replace({ name: ROUTE_NAMES.AUTH })
 }
 
 const goBackToList = () => {

--- a/src/views/ResultTypesView.vue
+++ b/src/views/ResultTypesView.vue
@@ -44,6 +44,7 @@ import ResultTypesGrid from '@/components/competencies/ResultTypesGrid.vue'
 import ResultTypeModal from '@/components/competencies/ResultTypeModal.vue'
 import type { ResultTypeConfig } from '@/types/evaluation'
 import { SupabaseResultTypesService } from '@/services/supabaseResultTypesService'
+import { ROUTE_NAMES } from '@/router/route-names'
 
 // Router
 const router = useRouter()
@@ -180,9 +181,8 @@ const goBack = () => {
 
 // Event handlers
 
-const handleLogout = () => {
-  console.log('Logout requested')
-  window.alert('Déconnexion - Fonctionnalité à venir')
+const handleLogout = async () => {
+  await router.replace({ name: ROUTE_NAMES.AUTH })
 }
 
 // Lifecycle

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -56,19 +56,119 @@
           </li>
         </ul>
       </SettingsSection>
+
+      <SettingsSection
+        id="account-settings"
+        title="Compte"
+        description="Actualisez vos informations personnelles et renforcez la sécurité de votre accès."
+      >
+        <section class="account-section" aria-live="polite">
+          <div v-if="accountMessage" class="account-feedback account-feedback--success">
+            <span class="material-symbols-outlined" aria-hidden="true">check_circle</span>
+            <span>{{ accountMessage }}</span>
+          </div>
+          <div v-if="accountError" class="account-feedback account-feedback--error" role="alert">
+            <span class="material-symbols-outlined" aria-hidden="true">error</span>
+            <span>{{ accountError }}</span>
+          </div>
+
+          <div class="account-grid">
+            <form class="settings-form" @submit.prevent="handleProfileSubmit">
+              <h3 class="settings-form__title">Identité</h3>
+              <p class="settings-form__description">
+                Ce nom sera utilisé dans les exports et communications.
+              </p>
+              <label class="settings-field">
+                <span class="settings-label">Nom complet</span>
+                <input
+                  v-model="profileForm.fullName"
+                  type="text"
+                  name="full-name"
+                  autocomplete="name"
+                  required
+                />
+              </label>
+              <button
+                type="submit"
+                class="settings-button"
+                :disabled="!canUpdateProfile || isUpdatingProfile"
+              >
+                {{ isUpdatingProfile ? 'Enregistrement...' : 'Mettre à jour le profil' }}
+              </button>
+            </form>
+
+            <form class="settings-form" @submit.prevent="handlePasswordSubmit">
+              <h3 class="settings-form__title">Mot de passe</h3>
+              <p class="settings-form__description">
+                Utilisez un mot de passe unique de 12 caractères minimum avec lettres et chiffres.
+              </p>
+              <label class="settings-field">
+                <span class="settings-label">Nouveau mot de passe</span>
+                <input
+                  v-model="passwordForm.newPassword"
+                  type="password"
+                  name="new-password"
+                  autocomplete="new-password"
+                  minlength="12"
+                  required
+                />
+              </label>
+              <label class="settings-field">
+                <span class="settings-label">Confirmation</span>
+                <input
+                  v-model="passwordForm.confirmPassword"
+                  type="password"
+                  name="confirm-password"
+                  autocomplete="new-password"
+                  minlength="12"
+                  required
+                />
+              </label>
+              <button
+                type="submit"
+                class="settings-button"
+                :disabled="!canUpdatePassword || isUpdatingPassword"
+              >
+                {{ isUpdatingPassword ? 'Mise à jour...' : 'Modifier le mot de passe' }}
+              </button>
+            </form>
+          </div>
+
+          <div class="verification-panel">
+            <h3 class="settings-form__title">Sécurité de l'adresse e-mail</h3>
+            <p class="verification-email">Adresse de connexion : <strong>{{ userEmail }}</strong></p>
+            <p v-if="isEmailVerified" class="verification-status verification-status--success">
+              Votre adresse e-mail est vérifiée.
+            </p>
+            <div v-else class="verification-status verification-status--warning">
+              <p>Votre adresse e-mail n'est pas encore vérifiée.</p>
+              <button
+                type="button"
+                class="text-button"
+                :disabled="isResendingVerification"
+                @click="handleResendVerification"
+              >
+                {{ isResendingVerification ? 'Envoi en cours...' : "Renvoyer l'e-mail de confirmation" }}
+              </button>
+            </div>
+          </div>
+        </section>
+      </SettingsSection>
     </main>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useSettingsStore } from '@/stores/settingsStore'
 import SettingsSection from '@/components/settings/SettingsSection.vue'
 import SettingsSwitch from '@/components/settings/SettingsSwitch.vue'
+import { useAuthStore } from '@/stores/authStore'
 
 const router = useRouter()
 const { showConsoleLogos, setShowConsoleLogos, isDarkThemeEnabled, setThemePreference } = useSettingsStore()
+const authStore = useAuthStore()
 
 const isConsoleLogoEnabled = computed(() => showConsoleLogos.value)
 const isDarkModeEnabled = computed(() => isDarkThemeEnabled.value)
@@ -82,6 +182,123 @@ const consoleLogoModel = computed({
   get: () => isConsoleLogoEnabled.value,
   set: (value: boolean) => setShowConsoleLogos(value)
 })
+
+const profileForm = reactive({
+  fullName: ''
+})
+
+const passwordForm = reactive({
+  newPassword: '',
+  confirmPassword: ''
+})
+
+const accountMessage = ref<string | null>(null)
+const accountError = ref<string | null>(null)
+const isUpdatingProfile = ref(false)
+const isUpdatingPassword = ref(false)
+const isResendingVerification = ref(false)
+
+const displayName = computed(() => authStore.displayName.value)
+const userEmail = computed(() => authStore.userEmail.value)
+const isEmailVerified = computed(() => authStore.isEmailVerified.value)
+
+watch(displayName, (value) => {
+  profileForm.fullName = value
+}, { immediate: true })
+
+const trimmedFullName = computed(() => profileForm.fullName.trim())
+
+const passwordHasLetters = computed(() => /[A-Za-zÀ-ÿ]/.test(passwordForm.newPassword))
+const passwordHasNumbers = computed(() => /\d/.test(passwordForm.newPassword))
+
+const canUpdateProfile = computed(() => {
+  return trimmedFullName.value.length >= 2 && trimmedFullName.value !== displayName.value.trim()
+})
+
+const canUpdatePassword = computed(() => {
+  return (
+    passwordForm.newPassword.length >= 12 &&
+    passwordHasLetters.value &&
+    passwordHasNumbers.value &&
+    passwordForm.newPassword === passwordForm.confirmPassword
+  )
+})
+
+const resetAccountFeedback = () => {
+  accountMessage.value = null
+  accountError.value = null
+  authStore.resetError()
+}
+
+const translateAccountError = (error: unknown) => {
+  if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: string }).message === 'string') {
+    const message = (error as { message?: string }).message?.toLowerCase?.() ?? ''
+    if (message.includes('password')) {
+      return 'Le mot de passe doit comporter au moins 12 caractères, avec lettres et chiffres.'
+    }
+    if (message.includes('rate limit')) {
+      return 'Vous avez récemment effectué cette action. Merci de patienter avant de réessayer.'
+    }
+    if (message.includes('email')) {
+      return 'Nous n\'avons pas pu mettre à jour l\'adresse e-mail pour le moment.'
+    }
+  }
+  return 'Une erreur est survenue. Merci de réessayer.'
+}
+
+const handleProfileSubmit = async () => {
+  resetAccountFeedback()
+  if (!canUpdateProfile.value) {
+    accountError.value = 'Aucun changement à enregistrer.'
+    return
+  }
+
+  isUpdatingProfile.value = true
+  const { error } = await authStore.updateProfile({ fullName: trimmedFullName.value })
+  isUpdatingProfile.value = false
+
+  if (error) {
+    accountError.value = translateAccountError(error)
+    return
+  }
+
+  accountMessage.value = 'Votre profil a été mis à jour avec succès.'
+}
+
+const handlePasswordSubmit = async () => {
+  resetAccountFeedback()
+  if (!canUpdatePassword.value) {
+    accountError.value = 'Le mot de passe doit comporter 12 caractères minimum, avec lettres et chiffres, et correspondre à la confirmation.'
+    return
+  }
+
+  isUpdatingPassword.value = true
+  const { error } = await authStore.updateProfile({ password: passwordForm.newPassword })
+  isUpdatingPassword.value = false
+
+  if (error) {
+    accountError.value = translateAccountError(error)
+    return
+  }
+
+  passwordForm.newPassword = ''
+  passwordForm.confirmPassword = ''
+  accountMessage.value = 'Votre mot de passe a été mis à jour.'
+}
+
+const handleResendVerification = async () => {
+  resetAccountFeedback()
+  isResendingVerification.value = true
+  const { error } = await authStore.resendEmailVerification()
+  isResendingVerification.value = false
+
+  if (error) {
+    accountError.value = translateAccountError(error)
+    return
+  }
+
+  accountMessage.value = 'Un nouvel e-mail de confirmation vient de vous être envoyé.'
+}
 
 // Event handlers
 const handleClose = () => {
@@ -239,5 +456,164 @@ const handleClose = () => {
   display: flex;
   align-items: center;
   flex-shrink: 0;
+}
+
+.account-section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.account-feedback {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-weight: 600;
+}
+
+.account-feedback--success {
+  background: color-mix(in srgb, var(--md-sys-color-primary) 12%, transparent);
+  color: var(--md-sys-color-primary);
+}
+
+.account-feedback--error {
+  background: color-mix(in srgb, var(--md-sys-color-error) 12%, transparent);
+  color: var(--md-sys-color-error);
+}
+
+.account-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 16px;
+  background: var(--md-sys-color-surface-container);
+  box-shadow: var(--md-sys-elevation-level1);
+}
+
+.settings-form__title {
+  margin: 0;
+  font-size: 1.125rem;
+  color: var(--md-sys-color-on-surface);
+}
+
+.settings-form__description {
+  margin: 0;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.95rem;
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-field input {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+  font-size: 1rem;
+}
+
+.settings-field input:focus {
+  outline: none;
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--md-sys-color-primary) 24%, transparent);
+}
+
+.settings-label {
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface);
+}
+
+.settings-button {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 20px;
+  border: none;
+  border-radius: 999px;
+  background: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.settings-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.settings-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: var(--md-sys-elevation-level2);
+}
+
+.verification-panel {
+  padding: 20px;
+  border-radius: 16px;
+  background: var(--md-sys-color-surface-container);
+  box-shadow: var(--md-sys-elevation-level1);
+}
+
+.verification-email {
+  margin: 0 0 8px;
+  color: var(--md-sys-color-on-surface);
+}
+
+.verification-status {
+  margin: 0;
+  font-weight: 600;
+}
+
+.verification-status--success {
+  color: var(--md-sys-color-secondary);
+}
+
+.verification-status--warning {
+  color: var(--md-sys-color-error);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.text-button {
+  border: none;
+  background: none;
+  color: var(--md-sys-color-primary);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.text-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 600px) {
+  .account-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-form,
+  .verification-panel {
+    padding: 16px;
+  }
 }
 </style>

--- a/src/views/StudentsView.vue
+++ b/src/views/StudentsView.vue
@@ -50,9 +50,10 @@ import StudentsList from '@/components/students/StudentsList.vue'
 import StudentModals from '@/components/students/StudentModals.vue'
 import type { Student } from '../types/evaluation'
 import { useStudentsStore } from '../stores/studentsStore'
+import { ROUTE_NAMES } from '@/router/route-names'
 
 // Router
-const $router = useRouter()
+const router = useRouter()
 
 // Store
 const studentsStore = useStudentsStore()
@@ -97,9 +98,8 @@ const filteredStudents = computed(() => {
 
 // Event handlers
 
-const handleLogout = () => {
-  console.log('Logout requested')
-  window.alert('Déconnexion - Fonctionnalité à venir')
+const handleLogout = async () => {
+  await router.replace({ name: ROUTE_NAMES.AUTH })
 }
 
 const handleAddStudent = () => {

--- a/src/views/WelcomeView.vue
+++ b/src/views/WelcomeView.vue
@@ -31,10 +31,13 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
+import { useRouter } from 'vue-router'
 import CenterAppBar from '@/components/common/CenterAppBar.vue'
+import { ROUTE_NAMES } from '@/router/route-names'
 
 // State
 const isScrolled = ref(false)
+const router = useRouter()
 
 // Scroll handling
 const handleScroll = () => {
@@ -44,9 +47,8 @@ const handleScroll = () => {
 
 // Event handlers
 
-const handleLogout = () => {
-  console.log('Logout requested')
-  window.alert('Déconnexion - Fonctionnalité à venir')
+const handleLogout = async () => {
+  await router.replace({ name: ROUTE_NAMES.AUTH })
 }
 
 // Lifecycle

--- a/supabase/templates/README.md
+++ b/supabase/templates/README.md
@@ -1,0 +1,30 @@
+# Modèles d'e-mails Supabase
+
+Ces modèles HTML permettent de personnaliser les e-mails envoyés par Supabase pour l'authentification (confirmation, lien magique, réinitialisation de mot de passe). Ils respectent la charte graphique de l'application **Évaluations** et utilisent des couleurs contrastées compatibles avec le mode clair/sombre.
+
+## Placeholders disponibles
+
+Supabase remplace automatiquement les variables suivantes lors de l'envoi :
+
+- `{{ .Email }}` : adresse e-mail du destinataire.
+- `{{ .ConfirmationURL }}` : lien sécurisé pour confirmer l'inscription ou réinitialiser le mot de passe.
+- `{{ .ActionLink }}` : lien utilisé pour les connexions via lien magique.
+- `{{ .SiteURL }}` : URL publique du projet.
+
+## Mise en place
+
+1. Dans le tableau de bord Supabase, rendez-vous dans **Authentication → Email Templates**.
+2. Copiez-collez le contenu du fichier correspondant :
+   - `account-confirmation.html` pour l'e-mail de confirmation d'inscription.
+   - `password-reset.html` pour la réinitialisation de mot de passe.
+   - `magic-link.html` pour les connexions en un clic.
+3. Activez l'option « Custom SMTP » si vous utilisez un serveur d'envoi spécifique.
+4. Testez chaque modèle en utilisant la fonctionnalité « Send Test Email » de Supabase.
+
+> 💡 **Astuce sécurité** : gardez la durée de validité des liens la plus courte possible dans Supabase (15 à 60 minutes) et forcez l'ouverture dans un navigateur sécurisé (`rel="noopener"`).
+
+## Bonnes pratiques de maintenance
+
+- Conservez ces fichiers sous contrôle de version afin d'historiser les changements.
+- Synchronisez régulièrement les modèles depuis Supabase vers ce dossier après modification côté dashboard.
+- Utilisez des formulations inclusives et précises : chaque modèle indique la durée de validité et la marche à suivre en cas d'action non sollicitée.

--- a/supabase/templates/account-confirmation.html
+++ b/supabase/templates/account-confirmation.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Confirmez votre adresse e-mail</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        background-color: #f5f5f5;
+        color: #1d1b20;
+      }
+      .wrapper {
+        width: 100%;
+        background-color: #f5f5f5;
+        padding: 32px 16px;
+      }
+      .email-container {
+        max-width: 560px;
+        margin: 0 auto;
+        background: #ffffff;
+        border-radius: 18px;
+        padding: 32px;
+        box-shadow: 0 18px 40px rgba(31, 41, 55, 0.08);
+      }
+      h1 {
+        font-size: 24px;
+        margin: 0 0 16px;
+      }
+      p {
+        line-height: 1.6;
+        margin: 0 0 16px;
+      }
+      .button {
+        display: inline-block;
+        padding: 14px 24px;
+        border-radius: 999px;
+        background-color: #6750a4;
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        margin: 16px 0;
+      }
+      .link-hint {
+        font-size: 14px;
+        color: #49454f;
+      }
+      .footer {
+        margin-top: 32px;
+        font-size: 12px;
+        color: #6d6d6d;
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background-color: #1d1b20;
+          color: #e7e0ec;
+        }
+        .wrapper {
+          background-color: #1d1b20;
+        }
+        .email-container {
+          background: #2b2930;
+          box-shadow: none;
+        }
+        .link-hint {
+          color: #cac4d0;
+        }
+        .footer {
+          color: #cac4d0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="email-container">
+        <p>Bonjour {{ .Email }},</p>
+        <h1>Confirmez votre adresse e-mail</h1>
+        <p>
+          Merci de rejoindre la plateforme <strong>Évaluations</strong>. Cliquez sur le bouton ci-dessous pour confirmer votre
+          adresse e-mail et activer votre compte.
+        </p>
+        <p style="text-align: center">
+          <a class="button" href="{{ .ConfirmationURL }}" target="_blank" rel="noopener">Confirmer mon e-mail</a>
+        </p>
+        <p class="link-hint">
+          Le lien est valable pendant 24 heures. Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre
+          navigateur :<br />
+          <span style="word-break: break-all">{{ .ConfirmationURL }}</span>
+        </p>
+        <p>Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer ce message.</p>
+        <p class="footer">
+          Cet e-mail vous est envoyé automatiquement par Supabase pour le compte de la plateforme Évaluations.
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/supabase/templates/magic-link.html
+++ b/supabase/templates/magic-link.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Connexion instantanée</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        background-color: #f5f5f5;
+        color: #1d1b20;
+      }
+      .wrapper {
+        width: 100%;
+        padding: 32px 16px;
+        background: #f5f5f5;
+      }
+      .email-container {
+        max-width: 560px;
+        margin: 0 auto;
+        background: #ffffff;
+        border-radius: 18px;
+        padding: 32px;
+        box-shadow: 0 18px 40px rgba(31, 41, 55, 0.08);
+      }
+      h1 {
+        font-size: 24px;
+        margin: 0 0 16px;
+      }
+      p {
+        line-height: 1.6;
+        margin: 0 0 16px;
+      }
+      .button {
+        display: inline-block;
+        padding: 14px 24px;
+        border-radius: 999px;
+        background-color: #6750a4;
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        margin: 16px 0;
+      }
+      .link-hint {
+        font-size: 14px;
+        color: #49454f;
+      }
+      .footer {
+        margin-top: 32px;
+        font-size: 12px;
+        color: #6d6d6d;
+      }
+      @media (prefers-color-scheme: dark) {
+        body { background-color: #1d1b20; color: #e7e0ec; }
+        .wrapper { background-color: #1d1b20; }
+        .email-container { background: #2b2930; box-shadow: none; }
+        .link-hint { color: #cac4d0; }
+        .footer { color: #cac4d0; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="email-container">
+        <p>Bonjour {{ .Email }},</p>
+        <h1>Connexion en un clic</h1>
+        <p>
+          Utilisez le bouton ci-dessous pour ouvrir immédiatement la plateforme Évaluations. Ce lien est unique et expirera après
+          son premier usage.
+        </p>
+        <p style="text-align: center">
+          <a class="button" href="{{ .ActionLink }}" target="_blank" rel="noopener">Accéder à Évaluations</a>
+        </p>
+        <p class="link-hint">Ce lien expirera automatiquement dans quelques minutes ou après utilisation.</p>
+        <p class="footer">Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet e-mail.</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/supabase/templates/password-reset.html
+++ b/supabase/templates/password-reset.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Réinitialisez votre mot de passe</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        background-color: #f5f5f5;
+        color: #1d1b20;
+      }
+      .wrapper {
+        width: 100%;
+        padding: 32px 16px;
+        background: #f5f5f5;
+      }
+      .email-container {
+        max-width: 560px;
+        margin: 0 auto;
+        background: #ffffff;
+        border-radius: 18px;
+        padding: 32px;
+        box-shadow: 0 18px 40px rgba(31, 41, 55, 0.08);
+      }
+      h1 {
+        font-size: 24px;
+        margin: 0 0 16px;
+      }
+      p {
+        line-height: 1.6;
+        margin: 0 0 16px;
+      }
+      .button {
+        display: inline-block;
+        padding: 14px 24px;
+        border-radius: 999px;
+        background-color: #6750a4;
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        margin: 16px 0;
+      }
+      .link-hint {
+        font-size: 14px;
+        color: #49454f;
+      }
+      .footer {
+        margin-top: 32px;
+        font-size: 12px;
+        color: #6d6d6d;
+      }
+      @media (prefers-color-scheme: dark) {
+        body { background-color: #1d1b20; color: #e7e0ec; }
+        .wrapper { background-color: #1d1b20; }
+        .email-container { background: #2b2930; box-shadow: none; }
+        .link-hint { color: #cac4d0; }
+        .footer { color: #cac4d0; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="email-container">
+        <p>Bonjour {{ .Email }},</p>
+        <h1>Réinitialisez votre mot de passe</h1>
+        <p>
+          Nous avons reçu une demande de réinitialisation du mot de passe pour votre compte Évaluations. Cliquez sur le bouton
+          ci-dessous pour définir un nouveau mot de passe.
+        </p>
+        <p style="text-align: center">
+          <a class="button" href="{{ .ConfirmationURL }}" target="_blank" rel="noopener">Choisir un nouveau mot de passe</a>
+        </p>
+        <p class="link-hint">
+          Ce lien est valable 60 minutes. Si vous n'avez pas demandé de réinitialisation, ignorez simplement cet e-mail.
+        </p>
+        <p class="footer">Besoin d'aide ? Contactez l'administrateur de votre établissement.</p>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- fall back to an in-memory Supabase mock and emit a single console warning when credentials are missing to avoid slow localhost calls
- guard auth bootstrap with a shared initialization promise, update redirect handling, and reuse a shared session applier for cleaner state transitions
- sanitize redirect query arrays in the auth views and clear sensitive form values after successful submission

## Testing
- npm run lint
- npm run test:unit:run
- npm run build
- npm run lighthouse

------
https://chatgpt.com/codex/tasks/task_e_68d45e83545c8320867a5108d172bbdb