### PR TITLE
Fix lint warnings by replacing any with explicit types

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -63,7 +63,10 @@ export default [
         KeyboardEvent: 'readonly',
         FocusEvent: 'readonly',
         FileReader: 'readonly',
-        alert: 'readonly'
+        alert: 'readonly',
+        Deno: 'readonly',
+        Request: 'readonly',
+        Response: 'readonly'
       }
     },
     plugins: {

--- a/src/components/competencies/CompetencyTree.vue
+++ b/src/components/competencies/CompetencyTree.vue
@@ -195,7 +195,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import type { Domain } from '@/types/evaluation'
+import type { Domain, Field, Competency, SpecificCompetency } from '@/types/evaluation'
 
 interface Props {
   domains: Domain[]
@@ -205,14 +205,26 @@ interface Emits {
   (e: 'add-field', domain: Domain): void
   (e: 'edit-domain', domain: Domain): void
   (e: 'delete-domain', domain: Domain): void
-  (e: 'add-competency', field: any, domain: Domain): void
-  (e: 'edit-field', field: any, domain: Domain): void
-  (e: 'delete-field', field: any, domain: Domain): void
-  (e: 'edit-competency', competency: any, field: any, domain: Domain): void
-  (e: 'delete-competency', competency: any, field: any, domain: Domain): void
-  (e: 'add-specific-competency', competency: any, field: any, domain: Domain): void
-  (e: 'edit-specific-competency', specificCompetency: any, competency: any, field: any, domain: Domain): void
-  (e: 'delete-specific-competency', specificCompetency: any, competency: any, field: any, domain: Domain): void
+  (e: 'add-competency', field: Field, domain: Domain): void
+  (e: 'edit-field', field: Field, domain: Domain): void
+  (e: 'delete-field', field: Field, domain: Domain): void
+  (e: 'edit-competency', competency: Competency, field: Field, domain: Domain): void
+  (e: 'delete-competency', competency: Competency, field: Field, domain: Domain): void
+  (e: 'add-specific-competency', competency: Competency, field: Field, domain: Domain): void
+  (
+    e: 'edit-specific-competency',
+    specificCompetency: SpecificCompetency,
+    competency: Competency,
+    field: Field,
+    domain: Domain
+  ): void
+  (
+    e: 'delete-specific-competency',
+    specificCompetency: SpecificCompetency,
+    competency: Competency,
+    field: Field,
+    domain: Domain
+  ): void
 }
 
 defineProps<Props>()

--- a/src/services/emailRestrictionsService.ts
+++ b/src/services/emailRestrictionsService.ts
@@ -107,7 +107,11 @@ export const emailRestrictionsService = {
   ): Promise<EmailRestriction> {
     try {
       // Normaliser les données de mise à jour
-      const normalizedUpdates: any = { ...updates }
+      type EmailRestrictionUpdate = Partial<Omit<CreateEmailRestrictionData, 'description'>> & {
+        description?: string | null
+      }
+
+      const normalizedUpdates: EmailRestrictionUpdate = { ...updates }
       if (updates.value) {
         normalizedUpdates.value = updates.value.toLowerCase().trim()
       }

--- a/src/services/supabaseClassesService.ts
+++ b/src/services/supabaseClassesService.ts
@@ -1,16 +1,16 @@
 import type { Database } from '../types/supabase'
+import type { Class } from '@/types/evaluation'
 import { supabase } from '../lib/supabase'
 
 type ClassInsert = Database['public']['Tables']['classes']['Insert']
 type ClassUpdate = Database['public']['Tables']['classes']['Update']
-
 type UserClass = Database['public']['Tables']['user_classes']['Row']
 
 export class SupabaseClassesService {
   /**
    * Get all active classes
    */
-  async getClasses(): Promise<any[]> {
+  async getClasses(): Promise<Class[]> {
     try {
       const { data, error } = await supabase
         .from('classes')
@@ -25,10 +25,10 @@ export class SupabaseClassesService {
       return (data || []).map(cls => ({
         id: cls.id,
         name: cls.name,
-        description: cls.description,
+        description: cls.description ?? undefined,
         schoolYear: cls.school_year, // Map snake_case to camelCase
-        level: cls.level,
-        subject: cls.subject,
+        level: cls.level ?? undefined,
+        subject: cls.subject ?? undefined,
         active: cls.active,
         createdAt: cls.created_at,
         updatedAt: cls.updated_at
@@ -42,7 +42,7 @@ export class SupabaseClassesService {
   /**
    * Get classes for a specific user
    */
-  async getClassesForUser(userId: string): Promise<any[]> {
+  async getClassesForUser(userId: string): Promise<Class[]> {
     try {
       const { data, error } = await supabase
         .from('user_classes')
@@ -68,15 +68,15 @@ export class SupabaseClassesService {
       // Transform the data to return just the classes, filtering for active ones
       const classes = (data || [])
         .map(item => item.classes)
-        .filter(Boolean)
+        .filter((cls): cls is Database['public']['Tables']['classes']['Row'] => Boolean(cls))
         .filter(cls => cls.active)
         .map(cls => ({
           id: cls.id,
           name: cls.name,
-          description: cls.description,
+          description: cls.description ?? undefined,
           schoolYear: cls.school_year, // Map snake_case to camelCase
-          level: cls.level,
-          subject: cls.subject,
+          level: cls.level ?? undefined,
+          subject: cls.subject ?? undefined,
           active: cls.active,
           createdAt: cls.created_at,
           updatedAt: cls.updated_at
@@ -92,7 +92,7 @@ export class SupabaseClassesService {
   /**
    * Get a single class by ID
    */
-  async getClass(id: string): Promise<any | null> {
+  async getClass(id: string): Promise<Class | null> {
     try {
       const { data, error } = await supabase
         .from('classes')
@@ -107,10 +107,10 @@ export class SupabaseClassesService {
       return {
         id: data.id,
         name: data.name,
-        description: data.description,
+        description: data.description ?? undefined,
         schoolYear: data.school_year, // Map snake_case to camelCase
-        level: data.level,
-        subject: data.subject,
+        level: data.level ?? undefined,
+        subject: data.subject ?? undefined,
         active: data.active,
         createdAt: data.created_at,
         updatedAt: data.updated_at
@@ -124,7 +124,7 @@ export class SupabaseClassesService {
   /**
    * Create a new class
    */
-  async createClass(classData: ClassInsert): Promise<any> {
+  async createClass(classData: ClassInsert): Promise<Class> {
     try {
       const { data, error } = await supabase
         .from('classes')
@@ -137,10 +137,10 @@ export class SupabaseClassesService {
       return {
         id: data.id,
         name: data.name,
-        description: data.description,
+        description: data.description ?? undefined,
         schoolYear: data.school_year, // Map snake_case to camelCase
-        level: data.level,
-        subject: data.subject,
+        level: data.level ?? undefined,
+        subject: data.subject ?? undefined,
         active: data.active,
         createdAt: data.created_at,
         updatedAt: data.updated_at
@@ -154,7 +154,7 @@ export class SupabaseClassesService {
   /**
    * Update a class
    */
-  async updateClass(id: string, updates: ClassUpdate): Promise<any> {
+  async updateClass(id: string, updates: ClassUpdate): Promise<Class> {
     try {
       const { data, error } = await supabase
         .from('classes')
@@ -168,10 +168,10 @@ export class SupabaseClassesService {
       return {
         id: data.id,
         name: data.name,
-        description: data.description,
+        description: data.description ?? undefined,
         schoolYear: data.school_year, // Map snake_case to camelCase
-        level: data.level,
-        subject: data.subject,
+        level: data.level ?? undefined,
+        subject: data.subject ?? undefined,
         active: data.active,
         createdAt: data.created_at,
         updatedAt: data.updated_at

--- a/src/services/supabaseSchoolYearsService.ts
+++ b/src/services/supabaseSchoolYearsService.ts
@@ -1,4 +1,6 @@
 import { supabase } from '@/lib/supabase'
+import type { RealtimePostgresChangesPayload } from '@supabase/supabase-js'
+import type { Database } from '@/types/supabase'
 
 export interface SchoolYear {
   id: string
@@ -283,7 +285,11 @@ export const supabaseSchoolYearsService = {
   /**
    * Souscription aux changements des années scolaires (temps réel)
    */
-  subscribeToSchoolYears(callback: (payload: any) => void) {
+  subscribeToSchoolYears(
+    callback: (
+      payload: RealtimePostgresChangesPayload<Database['public']['Tables']['school_years']['Row']>
+    ) => void
+  ) {
     console.log('🔔 [SupabaseSchoolYears] Abonnement aux changements des années scolaires')
 
     return supabase

--- a/src/views/ClassDetailView.vue
+++ b/src/views/ClassDetailView.vue
@@ -137,7 +137,15 @@ import { useClassStore } from '@/stores/classStore'
 import { useSchoolYearStore } from '@/stores/schoolYearStore'
 import { useEvaluationStore } from '@/stores/evaluationStore'
 import { useLogout } from '@/composables/useLogout'
-// import type { Class } from '@/types/evaluation'
+
+interface ClassFormData {
+  name: string
+  description?: string
+  level?: string
+  subject?: string
+  schoolYear?: string
+  active?: boolean
+}
 
 interface Props {
   id: string
@@ -218,7 +226,7 @@ const handleCloseModal = () => {
   isSubmittingModal.value = false
 }
 
-const handleSubmitModal = async (classData: any) => {
+const handleSubmitModal = async (classData: ClassFormData) => {
   if (isSubmittingModal.value || !currentClass.value) return
 
   isSubmittingModal.value = true

--- a/src/views/ClassesView.vue
+++ b/src/views/ClassesView.vue
@@ -135,6 +135,15 @@ import { useLogout } from '@/composables/useLogout'
 import { getSchoolYearFilterStore } from '@/stores/schoolYearFilterStore'
 import type { Class } from '@/types/evaluation'
 
+interface ClassFormData {
+  name: string
+  description?: string
+  level?: string
+  subject?: string
+  schoolYear?: string
+  active?: boolean
+}
+
 // Router
 const router = useRouter()
 
@@ -280,7 +289,7 @@ const handleCloseModal = () => {
   isSubmittingModal.value = false
 }
 
-const handleSubmitModal = async (classData: any) => {
+const handleSubmitModal = async (classData: ClassFormData) => {
   if (isSubmittingModal.value) return
 
   isSubmittingModal.value = true

--- a/src/views/CompetenciesView.vue
+++ b/src/views/CompetenciesView.vue
@@ -53,7 +53,13 @@ import CenterAppBar from '@/components/common/CenterAppBar.vue'
 import MenuFAB from '@/components/common/MenuFAB.vue'
 import CompetencyTree from '@/components/competencies/CompetencyTree.vue'
 import CompetencyModals from '@/components/competencies/CompetencyModals.vue'
-import type { Domain, ResultTypeConfig } from '@/types/evaluation'
+import type {
+  Domain,
+  Field,
+  Competency,
+  SpecificCompetency,
+  ResultTypeConfig
+} from '@/types/evaluation'
 import { useCompetencyFrameworkStore } from '@/stores/studentsStore'
 import { SupabaseCompetenciesService } from '@/services/supabaseCompetenciesService'
 import { SupabaseResultTypesService } from '@/services/supabaseResultTypesService'
@@ -77,8 +83,31 @@ const frameworkWithDragDrop = computed(() => ({
   domains: competencyStore.framework.value.domains
 }))
 
+interface MenuFabItem {
+  key: string
+  icon: string
+  label: string
+  ariaLabel: string
+  type?: string
+}
+
+type CompetencyModalType = 'domain' | 'field' | 'competency' | 'specificCompetency'
+
+interface CompetencyModalData {
+  id?: string
+  name: string
+  description: string
+  resultTypeConfigId?: string
+}
+
+interface CompetencyModalContext {
+  domain?: Domain
+  field?: Field
+  competency?: Competency
+}
+
 // FAB Menu Items
-const competenciesMenuItems = ref([
+const competenciesMenuItems = ref<MenuFabItem[]>([
   {
     key: 'add-domain',
     icon: 'add',
@@ -96,10 +125,10 @@ const competenciesMenuItems = ref([
 ])
 
 // Modal states
-const modalsRef = ref()
+const modalsRef = ref<InstanceType<typeof CompetencyModals> | null>(null)
 
 // FAB Menu Handler
-const handleFabMenuClick = (item: any) => {
+const handleFabMenuClick = (item: MenuFabItem) => {
   console.log('FAB menu click:', item.key)
   switch (item.key) {
     case 'add-domain':
@@ -135,44 +164,54 @@ const openDeleteDomainModal = (domain: Domain) => {
 }
 
 // Field operations
-const openAddCompetencyModal = (field: any, domain: any) => {
+const openAddCompetencyModal = (field: Field, domain: Domain) => {
   console.log('Add competency to field:', field.name, 'in domain:', domain.name)
   modalsRef.value?.openAddDialog('competency', { domain, field })
 }
 
-const openEditFieldModal = (field: any, domain: any) => {
+const openEditFieldModal = (field: Field, domain: Domain) => {
   console.log('Edit field:', field.name, 'in domain:', domain.name)
   modalsRef.value?.openEditDialog('field', field, { domain })
 }
 
-const openDeleteFieldModal = (field: any, domain: any) => {
+const openDeleteFieldModal = (field: Field, domain: Domain) => {
   console.log('Delete field:', field.name, 'in domain:', domain.name)
   modalsRef.value?.openDeleteDialog('field', field, { domain })
 }
 
 // Competency operations
-const openEditCompetencyModal = (competency: any, field: any, domain: any) => {
+const openEditCompetencyModal = (competency: Competency, field: Field, domain: Domain) => {
   console.log('Edit competency:', competency.name, 'in field:', field.name)
   modalsRef.value?.openEditDialog('competency', competency, { domain, field })
 }
 
-const openDeleteCompetencyModal = (competency: any, field: any, domain: any) => {
+const openDeleteCompetencyModal = (competency: Competency, field: Field, domain: Domain) => {
   console.log('Delete competency:', competency.name, 'in field:', field.name)
   modalsRef.value?.openDeleteDialog('competency', competency, { domain, field })
 }
 
 // Specific competency operations
-const openAddSpecificCompetencyModal = (competency: any, field: any, domain: any) => {
+const openAddSpecificCompetencyModal = (competency: Competency, field: Field, domain: Domain) => {
   console.log('Add specific competency to:', competency.name)
   modalsRef.value?.openAddDialog('specificCompetency', { domain, field, competency })
 }
 
-const openEditSpecificCompetencyModal = (specificCompetency: any, competency: any, field: any, domain: any) => {
+const openEditSpecificCompetencyModal = (
+  specificCompetency: SpecificCompetency,
+  competency: Competency,
+  field: Field,
+  domain: Domain
+) => {
   console.log('Edit specific competency:', specificCompetency.name)
   modalsRef.value?.openEditDialog('specificCompetency', specificCompetency, { domain, field, competency })
 }
 
-const openDeleteSpecificCompetencyModal = (specificCompetency: any, competency: any, field: any, domain: any) => {
+const openDeleteSpecificCompetencyModal = (
+  specificCompetency: SpecificCompetency,
+  competency: Competency,
+  field: Field,
+  domain: Domain
+) => {
   console.log('Delete specific competency:', specificCompetency.name)
   modalsRef.value?.openDeleteDialog('specificCompetency', specificCompetency, { domain, field, competency })
 }
@@ -198,7 +237,13 @@ const openAddDomainModal = () => {
 // }
 
 // Modal event handlers
-const handleModalSave = async (data: { type: string; data: any; context?: any }) => {
+const handleModalSave = async (
+  data: {
+    type: CompetencyModalType
+    data: CompetencyModalData
+    context?: CompetencyModalContext
+  }
+) => {
   console.log('Modal save:', data)
 
   try {
@@ -273,7 +318,13 @@ const handleModalSave = async (data: { type: string; data: any; context?: any })
   }
 }
 
-const handleModalDelete = async (data: { type: string; item: any; context?: any }) => {
+const handleModalDelete = async (
+  data: {
+    type: CompetencyModalType
+    item: CompetencyModalData
+    context?: CompetencyModalContext
+  }
+) => {
   console.log('Modal delete:', data)
 
   try {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -295,7 +295,46 @@ const exportEvaluationResults = () => {
   }
 }
 
-const generateCSV = (data: any) => {
+interface ExportedResult {
+  studentId: string
+  result: string | null
+}
+
+interface ExportedCompetency {
+  id: string
+  name: string
+  domain: string
+  field: string
+  results: ExportedResult[]
+}
+
+interface ExportedStudent {
+  id: string
+  fullName: string
+}
+
+interface ExportSummary {
+  totalStudents: number
+  totalCompetencies: number
+  exportDate: string
+}
+
+interface ExportedEvaluationInfo {
+  id: string
+  name: string
+  description?: string
+  date: string
+  schoolYearFilter?: string
+}
+
+interface EvaluationExportData {
+  evaluation: ExportedEvaluationInfo
+  competencies: ExportedCompetency[]
+  students: ExportedStudent[]
+  summary: ExportSummary
+}
+
+const generateCSV = (data: EvaluationExportData) => {
   try {
     // Validate input data
     if (!data || !data.competencies || !Array.isArray(data.competencies)) {
@@ -307,15 +346,18 @@ const generateCSV = (data: any) => {
     }
 
     // Create headers
-    const headers = ['Élève', ...data.competencies.map((comp: any) => `"${comp.domain} - ${comp.field} - ${comp.name}"`)]
+    const headers = [
+      'Élève',
+      ...data.competencies.map(comp => `"${comp.domain} - ${comp.field} - ${comp.name}"`)
+    ]
     const csvRows = [headers.join(',')]
 
     // Add student rows
-    data.students.forEach((student: any) => {
+    data.students.forEach(student => {
       const row = [
         `"${student.fullName || 'Élève sans nom'}"`,
-        ...data.competencies.map((comp: any) => {
-          const result = comp.results?.find((r: any) => r.studentId === student.id)
+        ...data.competencies.map(comp => {
+          const result = comp.results.find(r => r.studentId === student.id)
           return result?.result ? `"${result.result}"` : '""'
         })
       ]

--- a/supabase/functions/auth-hook-email-validation/index.ts
+++ b/supabase/functions/auth-hook-email-validation/index.ts
@@ -1,12 +1,18 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts"
 import { createClient } from 'jsr:@supabase/supabase-js@2'
 
+interface WebhookRecord {
+  id: string
+  email?: string | null
+  [key: string]: unknown
+}
+
 interface WebhookPayload {
   type: string
   table: string
-  record: any
+  record: WebhookRecord
   schema: string
-  old_record?: any
+  old_record?: WebhookRecord | null
 }
 
 Deno.serve(async (req: Request) => {

--- a/tests/unit/pdfExport.spec.ts
+++ b/tests/unit/pdfExport.spec.ts
@@ -2,7 +2,21 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import AnalysisView from '@/views/AnalysisView.vue'
 
-const mockPdfInstances: any[] = []
+interface MockJsPdfInstance {
+  internal: {
+    pageSize: {
+      getWidth: () => number
+      getHeight: () => number
+    }
+  }
+  setFontSize: (...args: unknown[]) => void
+  text: (...args: unknown[]) => void
+  addImage: (...args: unknown[]) => void
+  addPage: (...args: unknown[]) => void
+  save: (...args: unknown[]) => void
+}
+
+const mockPdfInstances: MockJsPdfInstance[] = []
 
 const mockJsPDF = vi.fn(() => {
   const instance = {


### PR DESCRIPTION
## Summary
- replace remaining `any` usages in competency components, views, and Supabase services with explicit domain models
- add Deno runtime globals to the ESLint config so edge functions lint cleanly
- normalize Supabase service mappers to return typed camelCase DTOs and update csv export helpers with typed data structures

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8064082a083208b182b7d602ba62e